### PR TITLE
run pytest with xdist and forked

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_script:
   - pip freeze
 
 script:
-  - python -m pytest --color=yes --cov=terracotta --mysql-server="root@127.0.0.1"
+  - python -m pytest --color=yes --cov=terracotta --forked --mysql-server="root@127.0.0.1"
   - python -m pytest --color=yes tests/benchmarks.py
 
 after_success:

--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,7 @@ setup(
             'pytest-mypy',
             'pytest-flake8',
             'pytest-benchmark',
+            'pytest-xdist',
             'attrs>=17.4.0',
             'codecov',
             'colorlog',

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -88,7 +88,7 @@ VALID_EXPR = (
 
     # long expression
     (
-        '+'.join(['v1'] * 800), sum(OPERANDS['v1'] for _ in range(800))
+        '+'.join(['v1'] * 10), sum(OPERANDS['v1'] for _ in range(10))
     )
 )
 

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -88,7 +88,7 @@ VALID_EXPR = (
 
     # long expression
     (
-        '+'.join(['v1'] * 1000), sum(OPERANDS['v1'] for _ in range(1000))
+        '+'.join(['v1'] * 800), sum(OPERANDS['v1'] for _ in range(800))
     )
 )
 


### PR DESCRIPTION
As discussed in the context of another PR (https://github.com/DHI-GRAS/terracotta/pull/166#pullrequestreview-366467067), Flask apps like Terracotta have a lot of global state, since the fully configured app is instantiated upon import:

https://github.com/DHI-GRAS/terracotta/blob/279b840cd5d8372b5895beba6c71498656fb468b/terracotta/server/app.py#L16-L19

Multiple instances of the app are not meant to run in the same kernel, but this is what happens when pytest executes the tests one after the other in the same kernel and the state of one instance can influence the outcome of the other.

Maybe we can change that with `pytest-xdist`, where each test runs in its own process, adding considerable overhead, but perhaps more security.