### PR TITLE
Fix bugs related to small raster files

### DIFF
--- a/tests/scripts/test_optimize_rasters.py
+++ b/tests/scripts/test_optimize_rasters.py
@@ -1,4 +1,5 @@
 import warnings
+import traceback
 
 import rasterio
 import numpy as np
@@ -6,6 +7,29 @@ import numpy as np
 from click.testing import CliRunner
 
 import pytest
+
+
+def format_exception(result):
+    return ''.join(traceback.format_exception(*result.exc_info))
+
+
+@pytest.fixture()
+def tiny_raster_file(unoptimized_raster_file, tmpdir_factory):
+    tmpdir = tmpdir_factory.mktemp('tiny-raster')
+    outfile = tmpdir / 'tiny.tif'
+    with rasterio.open(str(unoptimized_raster_file)) as src:
+        profile = src.profile.copy()
+        profile.update(
+            width=100,
+            height=100,
+            blockxsize=256,
+            blockysize=256
+        )
+
+        with rasterio.open(str(outfile), 'w', **profile) as dst:
+            dst.write(src.read()[:100, :100])
+
+    yield outfile
 
 
 @pytest.mark.parametrize('in_memory', [True, None, False])
@@ -30,7 +54,7 @@ def test_optimize_rasters(unoptimized_raster_file, tmpdir, in_memory, reproject,
 
     result = runner.invoke(cli.cli, ['optimize-rasters', input_pattern, '-o', str(tmpdir), *flags])
 
-    assert result.exit_code == 0
+    assert result.exit_code == 0, format_exception(result)
     assert outfile.check()
 
     # validate files
@@ -42,6 +66,31 @@ def test_optimize_rasters(unoptimized_raster_file, tmpdir, in_memory, reproject,
 
     # check for data integrity
     with rasterio.open(str(unoptimized_raster_file)) as src1, rasterio.open(str(outfile)) as src2:
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore', 'invalid value encountered.*')
+            np.testing.assert_array_equal(src1.read(), src2.read())
+
+
+def test_optimize_rasters_small(tiny_raster_file, tmpdir):
+    from terracotta.cog import validate
+    from terracotta.scripts import cli
+
+    input_pattern = str(tiny_raster_file)
+    outfile = tmpdir / tiny_raster_file.basename
+
+    runner = CliRunner()
+    result = runner.invoke(cli.cli, ['optimize-rasters', input_pattern, '-o', str(tmpdir)])
+
+    assert result.exit_code == 0, format_exception(result)
+    assert outfile.check()
+
+    # validate files
+    # (small rasters don't need overviews, so input file is valid, too)
+    assert validate(str(tiny_raster_file))
+    assert validate(str(outfile))
+
+    # check for data integrity
+    with rasterio.open(str(tiny_raster_file)) as src1, rasterio.open(str(outfile)) as src2:
         with warnings.catch_warnings():
             warnings.filterwarnings('ignore', 'invalid value encountered.*')
             np.testing.assert_array_equal(src1.read(), src2.read())


### PR DESCRIPTION
`optimize-rasters` fails on rasters that are smaller than one block (#179)