### PR TITLE
Driver caching & MySQL credentials

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,6 @@ setup(
         'pyyaml>=3.10',  # downstream dependency of apispec
         'shapely',
         'rasterio>=1.0',
-        'url_normalize',
         'shapely',
         'toml',
         'tqdm'

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ setup(
         'pyyaml>=3.10',  # downstream dependency of apispec
         'shapely',
         'rasterio>=1.0',
+        'url_normalize',
         'shapely',
         'toml',
         'tqdm'

--- a/setup.py
+++ b/setup.py
@@ -88,18 +88,18 @@ setup(
             'flake8',
             'matplotlib',
             'moto',
-            'pymysql'
+            'pymysql<0.10'
         ],
         'docs': [
             'sphinx',
             'sphinx_autodoc_typehints',
             'sphinx-click',
-            'pymysql'
+            'pymysql<0.10'
         ],
         'recommended': [
             'colorlog',
             'crick',
-            'pymysql'
+            'pymysql<0.10'
         ]
     },
     # CLI

--- a/terracotta/cache.py
+++ b/terracotta/cache.py
@@ -9,7 +9,7 @@ import sys
 import zlib
 
 import numpy as np
-from cachetools import LFUCache
+from cachetools import LFUCache, Cache
 
 CompressionTuple = Tuple[bytes, bytes, str, Tuple[int, int]]
 SizeFunction = Callable[[CompressionTuple], int]
@@ -22,18 +22,22 @@ class CompressedLFUCache(LFUCache):
         super().__init__(maxsize, self._get_size)
         self.compression_level = compression_level
 
-    def __getitem__(self, key: Any) -> np.ma.MaskedArray:
-        compressed_item = super().__getitem__(key)
+    def __getitem__(self, key: Any,
+                    cache_getitem: Callable = Cache.__getitem__) -> np.ma.MaskedArray:
+        compressed_item = super().__getitem__(key, cache_getitem)
         return self._decompress_tuple(compressed_item)
 
-    def __setitem__(self, key: Any, value: np.ma.MaskedArray) -> None:
-        super().__setitem__(key, self._compress_ma(value))
+    def __setitem__(self, key: Any,
+                    value: np.ma.MaskedArray,
+                    cache_setitem: Callable = Cache.__setitem__) -> None:
+        val_compressed = self._compress_ma(value, self.compression_level)
+        super().__setitem__(key, val_compressed, cache_setitem)
 
-    def _compress_ma(self,
-                     arr: np.ma.MaskedArray) -> CompressionTuple:
-        compressed_data = zlib.compress(arr.data, self.compression_level)
+    @staticmethod
+    def _compress_ma(arr: np.ma.MaskedArray, compression_level: int) -> CompressionTuple:
+        compressed_data = zlib.compress(arr.data, compression_level)
         mask_to_int = np.packbits(arr.mask.astype(np.uint8))
-        compressed_mask = zlib.compress(mask_to_int, self.compression_level)
+        compressed_mask = zlib.compress(mask_to_int, compression_level)
         out = (
             compressed_data,
             compressed_mask,
@@ -42,8 +46,8 @@ class CompressedLFUCache(LFUCache):
         )
         return out
 
-    def _decompress_tuple(self,
-                          compressed_data: CompressionTuple) -> np.ma.MaskedArray:
+    @staticmethod
+    def _decompress_tuple(compressed_data: CompressionTuple) -> np.ma.MaskedArray:
         data_b, mask_b, dt, ds = compressed_data
         data = np.frombuffer(zlib.decompress(data_b), dtype=dt).reshape(ds)
         mask = np.frombuffer(zlib.decompress(mask_b), dtype=np.uint8)

--- a/terracotta/cmaps/generate_cmaps.py
+++ b/terracotta/cmaps/generate_cmaps.py
@@ -8,7 +8,7 @@ import matplotlib.cm as cm
 
 from terracotta.cmaps.get_cmaps import SUFFIX
 
-ALL_MAPS = cm.cmap_d
+ALL_MAPS = list(cm.cmaps_listed) + list(cm.datad)
 NUM_VALS = 255
 
 

--- a/terracotta/cmaps/generate_cmaps.py
+++ b/terracotta/cmaps/generate_cmaps.py
@@ -8,13 +8,14 @@ import matplotlib.cm as cm
 
 from terracotta.cmaps.get_cmaps import SUFFIX
 
-ALL_MAPS = list(cm.cmaps_listed) + list(cm.datad)
+ALL_CMAPS = list(cm.cmaps_listed) + list(cm.datad)
+ALL_CMAPS.extend([f'{cmap}_r' for cmap in ALL_CMAPS])
 NUM_VALS = 255
 
 
 def generate_maps(out_folder: str) -> None:
     x = np.linspace(0, 1, NUM_VALS)
-    for cmap in ALL_MAPS:
+    for cmap in ALL_CMAPS:
         print(cmap)
         cmap_fun = cm.get_cmap(cmap)
         cmap_vals = cmap_fun(x)

--- a/terracotta/config.py
+++ b/terracotta/config.py
@@ -67,10 +67,10 @@ class TerracottaSettings(NamedTuple):
     #: CORS allowed origins for tiles endpoints
     ALLOWED_ORIGINS_TILES: List[str] = []
 
-    #:
+    #: MySQL database username (if not given in driver path)
     MYSQL_USER: Optional[str] = None
 
-    #:
+    #: MySQL database password (if not given in driver path)
     MYSQL_PASSWORD: Optional[str] = None
 
 

--- a/terracotta/config.py
+++ b/terracotta/config.py
@@ -67,6 +67,12 @@ class TerracottaSettings(NamedTuple):
     #: CORS allowed origins for tiles endpoints
     ALLOWED_ORIGINS_TILES: List[str] = []
 
+    #:
+    MYSQL_USER: Optional[str] = None
+
+    #:
+    MYSQL_PASSWORD: Optional[str] = None
+
 
 AVAILABLE_SETTINGS: Tuple[str, ...] = tuple(TerracottaSettings._fields)
 
@@ -113,6 +119,9 @@ class SettingSchema(Schema):
 
     ALLOWED_ORIGINS_METADATA = fields.List(fields.String())
     ALLOWED_ORIGINS_TILES = fields.List(fields.String())
+
+    MYSQL_USER = fields.String()
+    MYSQL_PASSWORD = fields.String()
 
     @pre_load
     def decode_lists(self, data: Dict[str, Any], **kwargs: Any) -> Dict[str, Any]:

--- a/terracotta/drivers/__init__.py
+++ b/terracotta/drivers/__init__.py
@@ -79,9 +79,11 @@ def get_driver(url_or_path: URLOrPathType, provider: str = None) -> Driver:
     if isinstance(url_or_path, Path) or provider == 'sqlite':
         url_or_path = str(Path(url_or_path).resolve())
 
-    cache_key = (url_or_path, provider)
+    DriverClass = load_driver(provider)
+    normalized_path = DriverClass._normalize_path(url_or_path)
+    cache_key = (normalized_path, provider)
+
     if cache_key not in _DRIVER_CACHE:
-        DriverClass = load_driver(provider)
         _DRIVER_CACHE[cache_key] = DriverClass(url_or_path)
 
     return _DRIVER_CACHE[cache_key]

--- a/terracotta/drivers/base.py
+++ b/terracotta/drivers/base.py
@@ -35,6 +35,11 @@ class Driver(ABC):
     def __init__(self, url_or_path: str) -> None:
         self.path = url_or_path
 
+    @classmethod
+    def _normalize_path(cls, path: str) -> str:
+        """Convert given path to normalized version (that can be used for caching)"""
+        return path
+
     @abstractmethod
     def create(self, keys: Sequence[str], *,
                key_descriptions: Mapping[str, str] = None) -> None:

--- a/terracotta/drivers/mysql.py
+++ b/terracotta/drivers/mysql.py
@@ -5,7 +5,7 @@ to be present on disk.
 """
 
 from typing import (Tuple, Dict, Iterator, Sequence, Union,
-                    Mapping, Any, Optional, cast, TypeVar, NamedTuple)
+                    Mapping, Any, Optional, cast, TypeVar)
 from collections import OrderedDict
 import contextlib
 from contextlib import AbstractContextManager
@@ -18,6 +18,7 @@ import numpy as np
 import pymysql
 from pymysql.connections import Connection
 from pymysql.cursors import DictCursor
+from url_normalize import url_normalize
 
 from terracotta import get_settings, __version__
 from terracotta.drivers.raster_base import RasterDriver
@@ -44,12 +45,28 @@ def convert_exceptions(msg: str) -> Iterator:
         raise exceptions.InvalidDatabaseError(msg) from exc
 
 
-class MySQLCredentials(NamedTuple):
-    host: str
-    port: int
-    db: str
-    user: Optional[str] = None
-    password: Optional[str] = None
+class MySQLCredentials:
+    __slots__ = ('host', 'port', 'db', '_user', '_password')
+
+    def __init__(self,
+                 host: str,
+                 port: int,
+                 db: str,
+                 user: Optional[str] = None,
+                 password: Optional[str] = None):
+        self.host = host
+        self.port = port
+        self.db = db
+        self._user = user
+        self._password = password
+
+    @property
+    def user(self) -> Optional[str]:
+        return self._user or get_settings().MYSQL_USER
+
+    @property
+    def password(self) -> Optional[str]:
+        return self._password or get_settings().MYSQL_PASSWORD
 
 
 class MySQLDriver(RasterDriver):
@@ -97,7 +114,6 @@ class MySQLDriver(RasterDriver):
                 ``mysql://username:password@hostname/database``
 
         """
-
         settings = get_settings()
 
         self.DB_CONNECTION_TIMEOUT: int = settings.DB_CONNECTION_TIMEOUT
@@ -127,20 +143,20 @@ class MySQLDriver(RasterDriver):
         self._version_checked: bool = False
         self._db_keys: Optional[OrderedDict] = None
 
-        qualified_path = self._build_qualified_path(self._db_args)
+        # use normalized path to make sure username and password don't leak into __repr__
+        qualified_path = self._normalize_path(mysql_path)
         super().__init__(qualified_path)
 
-    @staticmethod
-    def _build_qualified_path(db_args: MySQLCredentials) -> str:
-        """Convert path to mysql://({USER}(:[REDACTED])@){HOST}:{PORT}/{DB}"""
-        qualified_path = ['mysql://']
-        if db_args.user:
-            qualified_path.append(f'{db_args.user}')
-            if db_args.password:
-                qualified_path.append(':[REDACTED]')
-            qualified_path.append('@')
-        qualified_path.append(f'{db_args.host}:{db_args.port}/{db_args.db}')
-        return ''.join(qualified_path)
+    @classmethod
+    def _normalize_path(cls, path: str) -> str:
+        parts = urlparse.urlparse(path)
+        path = urlparse.urlunparse([
+            parts.scheme or 'mysql',
+            # using hostname instead of netloc drops username and password
+            parts.hostname,
+            *parts[2:]
+        ])
+        return url_normalize(path)
 
     @staticmethod
     def _parse_db_name(con_params: ParseResult) -> str:
@@ -148,7 +164,7 @@ class MySQLDriver(RasterDriver):
             raise ValueError('database must be specified in MySQL path')
 
         path = con_params.path.strip('/')
-        if len(path.split('/')) != 1:
+        if '/' in path:
             raise ValueError('invalid database path')
 
         return path

--- a/terracotta/drivers/raster_base.py
+++ b/terracotta/drivers/raster_base.py
@@ -16,6 +16,7 @@ import threading
 
 import numpy as np
 import cachetools
+import cachetools.keys
 
 if TYPE_CHECKING:  # pragma: no cover
     from rasterio.io import DatasetReader  # noqa: F401

--- a/terracotta/drivers/sqlite.py
+++ b/terracotta/drivers/sqlite.py
@@ -105,6 +105,10 @@ class SQLiteDriver(RasterDriver):
 
         super().__init__(os.path.realpath(path))
 
+    @classmethod
+    def _normalize_path(cls, path: str) -> str:
+        return os.path.normpath(path)
+
     def connect(self) -> AbstractContextManager:
         return self._connect(check=True)
 

--- a/terracotta/drivers/sqlite.py
+++ b/terracotta/drivers/sqlite.py
@@ -107,7 +107,7 @@ class SQLiteDriver(RasterDriver):
 
     @classmethod
     def _normalize_path(cls, path: str) -> str:
-        return os.path.normpath(path)
+        return os.path.normpath(os.path.realpath(path))
 
     def connect(self) -> AbstractContextManager:
         return self._connect(check=True)

--- a/terracotta/drivers/sqlite_remote.py
+++ b/terracotta/drivers/sqlite_remote.py
@@ -14,6 +14,7 @@ import contextlib
 import urllib.parse as urlparse
 
 from cachetools import cachedmethod, TTLCache
+from url_normalize import url_normalize
 
 from terracotta import get_settings, exceptions
 from terracotta.drivers.sqlite import SQLiteDriver
@@ -106,6 +107,10 @@ class RemoteSQLiteDriver(SQLiteDriver):
         self._checkdb_cache = TTLCache(maxsize=1, ttl=settings.REMOTE_DB_CACHE_TTL)
 
         super().__init__(local_db_file.name)
+
+    @classmethod
+    def _normalize_path(cls, path: str) -> str:
+        return url_normalize(path)
 
     @cachedmethod(operator.attrgetter('_checkdb_cache'))
     @convert_exceptions('Could not retrieve database from S3')

--- a/terracotta/drivers/sqlite_remote.py
+++ b/terracotta/drivers/sqlite_remote.py
@@ -6,14 +6,12 @@ to be present on disk.
 
 from typing import Any, Iterator
 import os
+import time
 import tempfile
 import shutil
-import operator
 import logging
 import contextlib
 import urllib.parse as urlparse
-
-from cachetools import cachedmethod, TTLCache
 
 from terracotta import get_settings, exceptions
 from terracotta.drivers.sqlite import SQLiteDriver
@@ -76,7 +74,6 @@ class RemoteSQLiteDriver(SQLiteDriver):
         will throw a NotImplementedError.
 
     """
-    path: str
 
     def __init__(self, remote_path: str) -> None:
         """Initialize the RemoteSQLiteDriver.
@@ -102,8 +99,8 @@ class RemoteSQLiteDriver(SQLiteDriver):
         )
         local_db_file.close()
 
-        self._remote_path: str = str(remote_path)
-        self._checkdb_cache = TTLCache(maxsize=1, ttl=settings.REMOTE_DB_CACHE_TTL)
+        self._remote_path = str(remote_path)
+        self._last_updated = -float('inf')
 
         super().__init__(local_db_file.name)
 
@@ -122,12 +119,15 @@ class RemoteSQLiteDriver(SQLiteDriver):
         path = path.rstrip('/')
         return path
 
-    @cachedmethod(operator.attrgetter('_checkdb_cache'))
     @convert_exceptions('Could not retrieve database from S3')
     @trace('download_db_from_s3')
     def _update_db(self, remote_path: str, local_path: str) -> None:
-        logger.debug('Remote database cache expired, re-downloading')
-        _update_from_s3(remote_path, local_path)
+        settings = get_settings()
+
+        if self._last_updated < time.time() - settings.REMOTE_DB_CACHE_TTL:
+            logger.debug('Remote database cache expired, re-downloading')
+            _update_from_s3(remote_path, local_path)
+            self._last_updated = time.time()
 
     def _connection_callback(self) -> None:
         self._update_db(self._remote_path, self.path)

--- a/tests/drivers/test_drivers.py
+++ b/tests/drivers/test_drivers.py
@@ -48,6 +48,7 @@ def test_normalize_url(provider):
     from terracotta.drivers import load_driver
 
     scheme = 'mysql' if provider == 'mysql' else 'https'
+    port = 3306 if provider == 'mysql' else 443
 
     equivalent_urls = (
         'test.example.com/foo',
@@ -55,6 +56,7 @@ def test_normalize_url(provider):
         'test.example.com/foo/',
         f'{scheme}://test.example.com/foo',
         f'{scheme}://user:password@test.example.com/foo',
+        f'test.example.com:{port}/foo',
 
     )
 

--- a/tests/drivers/test_mysql.py
+++ b/tests/drivers/test_mysql.py
@@ -28,6 +28,8 @@ INVALID_TEST_CASES = [
 @pytest.mark.parametrize('case', TEST_CASES.keys())
 def test_path_parsing(case):
     from terracotta import drivers
+    # empty cache
+    drivers._DRIVER_CACHE = {}
 
     db = drivers.get_driver(case, provider='mysql')
     db_args = db._db_args

--- a/zappa_requirements.txt
+++ b/zappa_requirements.txt
@@ -8,6 +8,7 @@ numpy
 pillow
 shapely
 rasterio[s3]>=1.0
+url_normalize
 
 aws_xray_sdk
 boto3

--- a/zappa_requirements.txt
+++ b/zappa_requirements.txt
@@ -8,7 +8,6 @@ numpy
 pillow
 shapely
 rasterio[s3]>=1.0
-url_normalize
 
 aws_xray_sdk
 boto3


### PR DESCRIPTION
- Use normalized paths for driver cache (so `https://example.com`, `example.com/`, ~`https://example.com/foo/../`~, `root:pw@example.com` all return the same driver)
- Introduce config vars for MySQL credentials (fixes #187)

Needs some more test coverage.