### PR TITLE
Remove hostname url hardcoded

### DIFF
--- a/terracotta/client/app/src/App.tsx
+++ b/terracotta/client/app/src/App.tsx
@@ -82,7 +82,7 @@ const App: FC<Props> = ({ hostnameProp }) => {
 
   const initializeApp = (hostname: string | undefined) => {
     // sanitize hostname
-    hostname = 'https://4opg6b5hc3.execute-api.eu-central-1.amazonaws.com/development'
+
     if(hostname){
 
       if (hostname.charAt(hostname.length - 1) === '/') {


### PR DESCRIPTION
For development purposes, I have used that URL. When merging, that URL should not be hardcoded there.

Close #201 