### PR TITLE
optimize_rasters: skip_existing

### DIFF
--- a/terracotta/scripts/optimize_rasters.py
+++ b/terracotta/scripts/optimize_rasters.py
@@ -119,6 +119,9 @@ TemporaryRasterFile = _named_tempfile
     help='Output folder for cloud-optimized rasters. Subdirectories will be flattened.'
 )
 @click.option(
+    '--skip-existing', is_flag=True, default=False, help='Skip existing files'
+)
+@click.option(
     '--overwrite', is_flag=True, default=False, help='Force overwrite of existing files'
 )
 @click.option(
@@ -145,6 +148,7 @@ TemporaryRasterFile = _named_tempfile
 def optimize_rasters(raster_files: Sequence[Sequence[Path]],
                      output_folder: Path,
                      overwrite: bool = False,
+                     skip_existing: bool = False,
                      resampling_method: str = 'average',
                      reproject: bool = False,
                      in_memory: bool = None,
@@ -214,10 +218,13 @@ def optimize_rasters(raster_files: Sequence[Sequence[Path]],
 
             output_file = output_folder / input_file.with_suffix('.tif').name
 
-            if not overwrite and output_file.is_file():
-                raise click.BadParameter(
-                    f'Output file {output_file!s} exists (use --overwrite to ignore)'
-                )
+            if output_file.is_file():
+                if skip_existing:
+                    continue
+                if not overwrite:
+                    raise click.BadParameter(
+                        f'Output file {output_file!s} exists (use --overwrite to ignore)'
+                    )
 
             with contextlib.ExitStack() as es, warnings.catch_warnings():
                 warnings.filterwarnings('ignore', message='invalid value encountered.*')

--- a/terracotta/scripts/optimize_rasters.py
+++ b/terracotta/scripts/optimize_rasters.py
@@ -223,7 +223,7 @@ def optimize_rasters(raster_files: Sequence[Sequence[Path]],
                     continue
                 if not overwrite:
                     raise click.BadParameter(
-                        f'Output file {output_file!s} exists (use --overwrite to ignore)'
+                        f'Output file {output_file!s} exists (use --overwrite or --skip-existing)'
                     )
 
             with contextlib.ExitStack() as es, warnings.catch_warnings():

--- a/tests/scripts/test_optimize_rasters.py
+++ b/tests/scripts/test_optimize_rasters.py
@@ -169,7 +169,7 @@ def test_reoptimize(tmpdir, unoptimized_raster_file, extra_flag):
     # second time
     args = ['optimize-rasters', infile, '-o', str(outfile)]
     if extra_flag:
-        args.append(extra_flag)
+        args.append(f'--{extra_flag}')
 
     result = runner.invoke(cli.cli, args)
 

--- a/tests/scripts/test_optimize_rasters.py
+++ b/tests/scripts/test_optimize_rasters.py
@@ -154,16 +154,17 @@ def test_optimize_rasters_multiband(tmpdir, unoptimized_raster_file):
 def test_reoptimize(tmpdir, unoptimized_raster_file, skip_existing):
     from terracotta.scripts import cli
 
+    infile = str(unoptimized_raster_file.dirpath('*.tif'))
     outfile = tmpdir / 'out.tif'
 
     # first time
     runner = CliRunner()
-    args = ['optimize-rasters', unoptimized_raster_file, '-o', str(outfile)]
+    args = ['optimize-rasters', infile, '-o', str(outfile)]
     result = runner.invoke(cli.cli, args)
     assert result.exit_code == 0
 
     # second time
-    args = ['optimize-rasters', unoptimized_raster_file, '-o', str(outfile)]
+    args = ['optimize-rasters', infile, '-o', str(outfile)]
     if skip_existing:
         args.append("--skip-existing")
         result = runner.invoke(cli.cli, args)

--- a/tests/scripts/test_optimize_rasters.py
+++ b/tests/scripts/test_optimize_rasters.py
@@ -150,6 +150,7 @@ def test_optimize_rasters_multiband(tmpdir, unoptimized_raster_file):
             warnings.filterwarnings('ignore', 'invalid value encountered.*')
             np.testing.assert_array_equal(src1.read(), src2.read())
 
+
 @pytest.mark.parametrize('skip_existing', [True, False])
 def test_reoptimize(tmpdir, unoptimized_raster_file, skip_existing):
     from terracotta.scripts import cli

--- a/tests/scripts/test_optimize_rasters.py
+++ b/tests/scripts/test_optimize_rasters.py
@@ -1,5 +1,3 @@
-import os
-import shutil
 import warnings
 import traceback
 
@@ -158,6 +156,7 @@ def test_reoptimize(tmpdir, unoptimized_raster_file, skip_existing):
 
     outfile = tmpdir / 'out.tif'
 
+    # first time
     runner = CliRunner()
     args = ['optimize-rasters', unoptimized_raster_file, '-o', str(outfile)]
     result = runner.invoke(cli.cli, args)
@@ -171,4 +170,4 @@ def test_reoptimize(tmpdir, unoptimized_raster_file, skip_existing):
         assert result.exit_code == 0
     if not skip_existing:
         result = runner.invoke(cli.cli, args)
-        assert result.exit_code == 1
+        assert result.exit_code == 2

--- a/tests/scripts/test_optimize_rasters.py
+++ b/tests/scripts/test_optimize_rasters.py
@@ -152,7 +152,7 @@ def test_optimize_rasters_multiband(tmpdir, unoptimized_raster_file):
             np.testing.assert_array_equal(src1.read(), src2.read())
 
 
-@pytest.mark.parametrize('extra_flag', ['skip_existing', 'overwrite', None])
+@pytest.mark.parametrize('extra_flag', ['skip-existing', 'overwrite', None])
 def test_reoptimize(tmpdir, unoptimized_raster_file, extra_flag):
     from terracotta.scripts import cli
 
@@ -173,7 +173,7 @@ def test_reoptimize(tmpdir, unoptimized_raster_file, extra_flag):
 
     result = runner.invoke(cli.cli, args)
 
-    if extra_flag == 'skip_existing':
+    if extra_flag == 'skip-existing':
         assert result.exit_code == 0
         assert os.stat(outfile).st_ctime == ctime
     elif extra_flag == 'overwrite':


### PR DESCRIPTION
Adds new CLI flag for skipping existing outputs

https://github.com/DHI-GRAS/terracotta/blob/9716a82dd0d583d670b8fd1810713fdf26f7c6ec/terracotta/scripts/ingest.py#L28