### PR TITLE
Parallel raster optimisation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
         'apispec-webframeworks',
         'cachetools>=3.1.0',
         'click',
+        'click-spinner',
         'flask',
         'flask_cors',
         'marshmallow>=3.0.0',

--- a/terracotta/scripts/optimize_rasters.py
+++ b/terracotta/scripts/optimize_rasters.py
@@ -117,15 +117,10 @@ def _optimize_single_raster(
 ) -> None:
     output_file = output_folder / input_file.with_suffix('.tif').name
 
-    if output_file.is_file():
-        if skip_existing:
-            if not quiet:
-                click.echo(f'\r{input_file.name!r} {progress_suffix}')
-            return
-        if not overwrite:
-            raise click.BadParameter(
-                f'Output file {output_file!s} exists (use --overwrite or --skip-existing)'
-            )
+    if output_file.is_file() and skip_existing:
+        if not quiet:
+            click.echo(f'\r{input_file.name!r} skipped {progress_suffix}')
+        return
 
     if not quiet:
         click.echo(f'\r{input_file.name} ... {progress_suffix}')
@@ -265,6 +260,12 @@ def optimize_rasters(raster_files: Sequence[Sequence[Path]],
     for f in raster_files_flat:
         if not f.is_file():
             raise click.BadParameter(f'Input raster {f!s} is not a file')
+
+        output_file = output_folder / f.with_suffix('.tif').name
+        if output_file.is_file() and not (skip_existing or overwrite):
+            raise click.BadParameter(
+                f'Output file {f!s} exists (use --overwrite or --skip-existing)'
+            )
 
         with rasterio.open(str(f), 'r') as src:
             if src.count > 1 and not quiet:

--- a/terracotta/scripts/optimize_rasters.py
+++ b/terracotta/scripts/optimize_rasters.py
@@ -298,7 +298,7 @@ def optimize_rasters(raster_files: Sequence[Sequence[Path]],
         click.echo(f'Optimizing {len(raster_files_to_optimize)} {files_str} on {nproc} {processes_str}')
 
     with contextlib.ExitStack() as outer_env:
-        outer_env.enter_context(click_spinner.spinner(beep=False, disable=False, force=False, stream=sys.stdout))
+        outer_env.enter_context(click_spinner.spinner(beep=False, disable=quiet, force=False, stream=sys.stdout))
         outer_env.enter_context(rasterio.Env(**GDAL_CONFIG))
 
         if nproc > 1:

--- a/terracotta/scripts/optimize_rasters.py
+++ b/terracotta/scripts/optimize_rasters.py
@@ -5,6 +5,7 @@ Convert some raster files to cloud-optimized GeoTiff for use with Terracotta.
 
 from typing import Any, Sequence, Iterator, Union
 import os
+import sys
 import math
 import warnings
 import itertools
@@ -282,7 +283,8 @@ def optimize_rasters(raster_files: Sequence[Sequence[Path]],
         # insert newline for nicer progress bar style
         click.echo('')
 
-    with contextlib.ExitStack() as outer_env, click_spinner.spinner():
+    with contextlib.ExitStack() as outer_env, \
+         click_spinner.spinner(beep=False, disable=False, force=False, stream=sys.stdout):
         outer_env.enter_context(rasterio.Env(**GDAL_CONFIG))
 
         if cores == -1:

--- a/terracotta/scripts/optimize_rasters.py
+++ b/terracotta/scripts/optimize_rasters.py
@@ -120,7 +120,7 @@ def _optimize_single_raster(
     if output_file.is_file():
         if skip_existing:
             if not quiet:
-                click.echo(f'\rSkipping {input_file.name!r} {progress_suffix}')
+                click.echo(f'\r{input_file.name!r} {progress_suffix}')
             return
         if not overwrite:
             raise click.BadParameter(
@@ -128,7 +128,7 @@ def _optimize_single_raster(
             )
 
     if not quiet:
-        click.echo(f'\rOptimizing {input_file.name!r}... {progress_suffix}')
+        click.echo(f'\r{input_file.name} ... {progress_suffix}')
 
     with contextlib.ExitStack() as es, warnings.catch_warnings():
         warnings.filterwarnings('ignore', message='invalid value encountered.*')
@@ -185,9 +185,6 @@ def _optimize_single_raster(
             dst, str(output_file), copy_src_overviews=True,
             compress=compression, **COG_PROFILE
         )
-
-    if not quiet:
-        click.echo(f"\rOptimized {input_file.name!r}")
 
 
 @click.command(
@@ -292,8 +289,8 @@ def optimize_rasters(raster_files: Sequence[Sequence[Path]],
         if cores > 1:
             with concurrent.futures.ProcessPoolExecutor(max_workers=cores) as executor:
                 if not quiet:
-                    click.echo(f'\bOptimizing {len(raster_files_flat)} files '
-                               f'on {cores} processes...')
+                    click.echo(f'\rOptimizing {len(raster_files_flat)} files '
+                               f'on {cores} processes')
 
                 futures = [
                     executor.submit(

--- a/terracotta/scripts/optimize_rasters.py
+++ b/terracotta/scripts/optimize_rasters.py
@@ -111,16 +111,11 @@ TemporaryRasterFile = _named_tempfile
 
 
 def _optimize_single_raster(
-    input_file: Path, output_folder: Path, skip_existing: bool,
-    overwrite: bool, reproject: bool, rs_method: Any, in_memory: Union[bool, None],
+    input_file: Path, output_folder: Path,
+    reproject: bool, rs_method: Any, in_memory: Union[bool, None],
     compression: str, quiet: bool, progress_suffix: str
 ) -> None:
     output_file = output_folder / input_file.with_suffix('.tif').name
-
-    if output_file.is_file() and skip_existing:
-        if not quiet:
-            click.echo(f'\r{input_file.name!r} skipped {progress_suffix}')
-        return
 
     if not quiet:
         click.echo(f'\r{input_file.name} ... {progress_suffix}')
@@ -316,8 +311,6 @@ def optimize_rasters(raster_files: Sequence[Sequence[Path]],
                     _optimize_single_raster,
                     input_file,
                     output_folder,
-                    skip_existing,
-                    overwrite,
                     reproject,
                     rs_method,
                     in_memory,
@@ -338,8 +331,6 @@ def optimize_rasters(raster_files: Sequence[Sequence[Path]],
                 _optimize_single_raster(
                     input_file,
                     output_folder,
-                    skip_existing,
-                    overwrite,
                     reproject,
                     rs_method,
                     in_memory,

--- a/terracotta/scripts/optimize_rasters.py
+++ b/terracotta/scripts/optimize_rasters.py
@@ -110,12 +110,16 @@ def _named_tempfile(basedir: Union[str, Path]) -> Iterator[str]:
 TemporaryRasterFile = _named_tempfile
 
 
+def _output_file(output_folder: Path, input_file: Path) -> Path:
+    return output_folder / input_file.with_suffix('.tif').name
+
+
 def _optimize_single_raster(
     input_file: Path, output_folder: Path,
     reproject: bool, rs_method: Any, in_memory: Union[bool, None],
     compression: str, quiet: bool, progress_suffix: str
 ) -> None:
-    output_file = output_folder / input_file.with_suffix('.tif').name
+    output_file = _output_file(output_folder, input_file)
 
     if not quiet:
         click.echo(f'\r{input_file.name} ... {progress_suffix}')
@@ -264,7 +268,7 @@ def optimize_rasters(raster_files: Sequence[Sequence[Path]],
         if not f.is_file():
             raise click.BadParameter(f'Input raster {f!s} is not a file')
 
-        output_file = output_folder / f.with_suffix('.tif').name
+        output_file = _output_file(output_folder, f)
         if output_file.is_file():
             if not (skip_existing or overwrite):
                 raise click.BadParameter(

--- a/terracotta/scripts/optimize_rasters.py
+++ b/terracotta/scripts/optimize_rasters.py
@@ -220,7 +220,8 @@ def _optimize_single_raster(
 )
 @click.option(
     '--cores', default=1, type=click.INT,
-    help='Number of processes to use for multi-core processing [default: 1, i.e., single-core processing]'
+    help='Number of processes to use for multi-core processing'
+         '[default: 1, i.e., single-core processing]'
 )
 @click.option(
     '-q', '--quiet', is_flag=True, default=False, show_default=True,
@@ -285,7 +286,8 @@ def optimize_rasters(raster_files: Sequence[Sequence[Path]],
         outer_env.enter_context(rasterio.Env(**GDAL_CONFIG))
 
         with concurrent.futures.ProcessPoolExecutor(max_workers=cores) as executor:
-            pbar.write(f'Optimizing {len(raster_files_flat)} files on {executor._max_workers} process{"es" if executor._max_workers > 1 else ""}...')
+            pbar.write(f'Optimizing {len(raster_files_flat)} files on {cores} '
+                       f'process{"es" if cores > 1 else ""}...')
 
             futures = [
                 executor.submit(
@@ -301,7 +303,7 @@ def optimize_rasters(raster_files: Sequence[Sequence[Path]],
                 )
                 for input_file in raster_files_flat
             ]
-            
+
             for future in concurrent.futures.as_completed(futures):
                 file_name, pixel_count, action = future.result()
                 if not quiet:

--- a/terracotta/scripts/optimize_rasters.py
+++ b/terracotta/scripts/optimize_rasters.py
@@ -3,7 +3,7 @@
 Convert some raster files to cloud-optimized GeoTiff for use with Terracotta.
 """
 
-from typing import Any, Sequence, Iterator, Tuple, Union
+from typing import Any, Sequence, Iterator, Union
 import os
 import math
 import warnings
@@ -125,10 +125,10 @@ def _optimize_single_raster(
             raise click.BadParameter(
                 f'Output file {output_file!s} exists (use --overwrite or --skip-existing)'
             )
-    
+
     if not quiet:
         click.echo(f'\rOptimizing {input_file.name!r}...')
-    
+
     with contextlib.ExitStack() as es, warnings.catch_warnings():
         warnings.filterwarnings('ignore', message='invalid value encountered.*')
 
@@ -290,7 +290,8 @@ def optimize_rasters(raster_files: Sequence[Sequence[Path]],
         if cores > 1:
             with concurrent.futures.ProcessPoolExecutor(max_workers=cores) as executor:
                 if not quiet:
-                    click.echo(f'\bOptimizing {len(raster_files_flat)} files on {cores} processes...')
+                    click.echo(f'\bOptimizing {len(raster_files_flat)} files '
+                               f'on {cores} processes...')
 
                 futures = [
                     executor.submit(

--- a/terracotta/scripts/optimize_rasters.py
+++ b/terracotta/scripts/optimize_rasters.py
@@ -3,7 +3,7 @@
 Convert some raster files to cloud-optimized GeoTiff for use with Terracotta.
 """
 
-from typing import Any, Literal, Sequence, Iterator, Tuple, Union
+from typing import Any, Sequence, Iterator, Tuple, Union
 import os
 import math
 import warnings
@@ -113,7 +113,7 @@ def _optimize_single_raster(
     input_file: Path, output_folder: Path, skip_existing: bool,
     overwrite: bool, reproject: bool, rs_method: Any, in_memory: Union[bool, None],
     compression: str
-) -> Tuple[str, int, Literal['optimized', 'skipped']]:
+) -> Tuple[str, int, str]:
     output_file = output_folder / input_file.with_suffix('.tif').name
 
     if output_file.is_file():

--- a/terracotta/scripts/optimize_rasters.py
+++ b/terracotta/scripts/optimize_rasters.py
@@ -3,7 +3,7 @@
 Convert some raster files to cloud-optimized GeoTiff for use with Terracotta.
 """
 
-from typing import Any, Dict, Literal, Sequence, Iterator, Tuple, Union
+from typing import Any, Literal, Sequence, Iterator, Tuple, Union
 import os
 import math
 import warnings

--- a/terracotta/scripts/optimize_rasters.py
+++ b/terracotta/scripts/optimize_rasters.py
@@ -152,7 +152,7 @@ def _optimize_single_raster(
         # iterate over blocks
         windows = list(dst.block_windows(1))
 
-        for _, w in tqdm.tqdm(windows, desc='Reading', **sub_pbar_args):
+        for _, w in windows:
             block_data = vrt.read(window=w, indexes=[1])
             dst.write(block_data, window=w)
             block_mask = vrt.dataset_mask(window=w).astype('uint8')
@@ -172,17 +172,15 @@ def _optimize_single_raster(
 
         if max_overview_level > 0:
             overviews = [2 ** j for j in range(1, max_overview_level + 1)]
-            with tqdm.tqdm(desc='Creating overviews', total=1, **sub_pbar_args):
-                dst.build_overviews(overviews, rs_method)
+            dst.build_overviews(overviews, rs_method)
 
             dst.update_tags(ns='rio_overview', resampling=rs_method.value)
 
         # copy to destination (this is necessary to push overviews to start of file)
-        with tqdm.tqdm(desc='Compressing', total=1, **sub_pbar_args):
-            copy(
-                dst, str(output_file), copy_src_overviews=True,
-                compress=compression, **COG_PROFILE
-            )
+        copy(
+            dst, str(output_file), copy_src_overviews=True,
+            compress=compression, **COG_PROFILE
+        )
 
     return input_file.name, dst.height * dst.width, 'optimized'
 

--- a/terracotta/scripts/optimize_rasters.py
+++ b/terracotta/scripts/optimize_rasters.py
@@ -216,7 +216,7 @@ def _optimize_single_raster(
     help='Compression algorithm to use [default: auto (ZSTD if available, DEFLATE otherwise)]'
 )
 @click.option(
-    '--cores', default=1, type=click.INT,
+    '--nproc', default=1, type=click.INT,
     help='Number of processes to use for multi-core processing '
          '[default: 1, i.e., single-core processing] '
          'Set to -1 to use all available (logical) cores'
@@ -233,7 +233,7 @@ def optimize_rasters(raster_files: Sequence[Sequence[Path]],
                      reproject: bool = False,
                      in_memory: Union[bool, None] = None,
                      compression: str = 'auto',
-                     cores: int = 1,
+                     nproc: int = 1,
                      quiet: bool = False) -> None:
     """Optimize a collection of raster files for use with Terracotta.
 
@@ -285,13 +285,13 @@ def optimize_rasters(raster_files: Sequence[Sequence[Path]],
          click_spinner.spinner(beep=False, disable=False, force=False, stream=sys.stdout):
         outer_env.enter_context(rasterio.Env(**GDAL_CONFIG))
 
-        if cores == -1:
-            cores = os.cpu_count() or 1  # Default to 1 if `cpu_count` returns None
-        if cores > 1:
-            with concurrent.futures.ProcessPoolExecutor(max_workers=cores) as executor:
+        if nproc == -1:
+            nproc = os.cpu_count() or 1  # Default to 1 if `cpu_count` returns None
+        if nproc > 1:
+            with concurrent.futures.ProcessPoolExecutor(max_workers=nproc) as executor:
                 if not quiet:
                     click.echo(f'\rOptimizing {len(raster_files_flat)} files '
-                               f'on {cores} processes')
+                               f'on {nproc} processes')
 
                 futures = [
                     executor.submit(

--- a/terracotta/scripts/optimize_rasters.py
+++ b/terracotta/scripts/optimize_rasters.py
@@ -295,14 +295,21 @@ def optimize_rasters(raster_files: Sequence[Sequence[Path]],
     if not quiet:
         files_str = 'file' if len(raster_files_to_optimize) == 1 else 'files'
         processes_str = 'process' if nproc == 1 else 'processes'
-        click.echo(f'Optimizing {len(raster_files_to_optimize)} {files_str} on {nproc} {processes_str}')
+        click.echo(
+            f'Optimizing {len(raster_files_to_optimize)} {files_str} on {nproc} {processes_str}'
+        )
 
     with contextlib.ExitStack() as outer_env:
-        outer_env.enter_context(click_spinner.spinner(beep=False, disable=quiet, force=False, stream=sys.stdout))
+        outer_env.enter_context(click_spinner.spinner(beep=False,
+                                                      disable=quiet,
+                                                      force=False,
+                                                      stream=sys.stdout))
         outer_env.enter_context(rasterio.Env(**GDAL_CONFIG))
 
         if nproc > 1:
-            executor = outer_env.enter_context(concurrent.futures.ProcessPoolExecutor(max_workers=nproc))
+            executor = outer_env.enter_context(
+                concurrent.futures.ProcessPoolExecutor(max_workers=nproc)
+            )
 
             futures = {
                 executor.submit(

--- a/terracotta/scripts/optimize_rasters.py
+++ b/terracotta/scripts/optimize_rasters.py
@@ -220,8 +220,9 @@ def _optimize_single_raster(
 )
 @click.option(
     '--cores', default=1, type=click.INT,
-    help='Number of processes to use for multi-core processing'
-         '[default: 1, i.e., single-core processing]'
+    help='Number of processes to use for multi-core processing '
+         '[default: 1, i.e., single-core processing] '
+         'Set to -1 to use all available (logical) cores'
 )
 @click.option(
     '-q', '--quiet', is_flag=True, default=False, show_default=True,
@@ -285,6 +286,8 @@ def optimize_rasters(raster_files: Sequence[Sequence[Path]],
         ))
         outer_env.enter_context(rasterio.Env(**GDAL_CONFIG))
 
+        if cores == -1:
+            cores = os.cpu_count() or 1  # Default to 1 if `cpu_count` returns None
         with concurrent.futures.ProcessPoolExecutor(max_workers=cores) as executor:
             pbar.write(f'Optimizing {len(raster_files_flat)} files on {cores} '
                        f'process{"es" if cores > 1 else ""}...')

--- a/terracotta/scripts/optimize_rasters.py
+++ b/terracotta/scripts/optimize_rasters.py
@@ -112,7 +112,7 @@ TemporaryRasterFile = _named_tempfile
 def _optimize_single_raster(
     input_file: Path, output_folder: Path, skip_existing: bool,
     overwrite: bool, reproject: bool, rs_method: Any, in_memory: Union[bool, None],
-    compression: str, sub_pbar_args: Dict[str, Union[str, bool]]
+    compression: str
 ) -> Tuple[str, int, Literal['optimized', 'skipped']]:
     output_file = output_folder / input_file.with_suffix('.tif').name
 
@@ -285,12 +285,6 @@ def optimize_rasters(raster_files: Sequence[Sequence[Path]],
         # insert newline for nicer progress bar style
         click.echo('')
 
-    sub_pbar_args = dict(
-        disable=quiet,
-        leave=False,
-        bar_format='{l_bar}{bar}| {n_fmt}/{total_fmt}'
-    )
-
     with contextlib.ExitStack() as outer_env:
         pbar = outer_env.enter_context(tqdm.tqdm(
             total=total_pixels, smoothing=0, disable=quiet,
@@ -312,7 +306,7 @@ def optimize_rasters(raster_files: Sequence[Sequence[Path]],
                     _optimize_single_raster,
                     (
                         input_file, output_folder, skip_existing, overwrite, reproject,
-                        rs_method, in_memory, compression, sub_pbar_args
+                        rs_method, in_memory, compression
                     ),
                     callback=_update_pbar,
                     error_callback=_raise_exception

--- a/terracotta/scripts/optimize_rasters.py
+++ b/terracotta/scripts/optimize_rasters.py
@@ -245,6 +245,13 @@ def optimize_rasters(raster_files: Sequence[Sequence[Path]],
 
     Note that all rasters may only contain a single band.
     """
+    if overwrite and skip_existing:
+        raise click.BadOptionUsage(
+            '--overwrite and --skip-existing',
+            'Both --overwrite and --skip-existing flags are provided. '
+            'These are mutually exclusive. Please provide at max one of them'
+        )
+
     raster_files_flat = set(itertools.chain.from_iterable(raster_files))
 
     if not raster_files_flat:

--- a/tests/scripts/test_optimize_rasters.py
+++ b/tests/scripts/test_optimize_rasters.py
@@ -36,7 +36,9 @@ def tiny_raster_file(unoptimized_raster_file, tmpdir_factory):
 @pytest.mark.parametrize('in_memory', [True, None, False])
 @pytest.mark.parametrize('reproject', [True, False])
 @pytest.mark.parametrize('compression', ['auto', 'lzw', 'none'])
-def test_optimize_rasters(unoptimized_raster_file, tmpdir, in_memory, reproject, compression):
+@pytest.mark.parametrize('cores', [None, 1, 2, -1])
+def test_optimize_rasters(unoptimized_raster_file, tmpdir, in_memory,
+                          reproject, compression, cores):
     from terracotta.cog import validate
     from terracotta.scripts import cli
 
@@ -52,6 +54,9 @@ def test_optimize_rasters(unoptimized_raster_file, tmpdir, in_memory, reproject,
 
     if reproject:
         flags.append('--reproject')
+
+    if cores is not None:
+        flags.append('--cores=%i' % cores)
 
     result = runner.invoke(cli.cli, ['optimize-rasters', input_pattern, '-o', str(tmpdir), *flags])
 

--- a/tests/scripts/test_optimize_rasters.py
+++ b/tests/scripts/test_optimize_rasters.py
@@ -56,7 +56,7 @@ def test_optimize_rasters(unoptimized_raster_file, tmpdir, in_memory,
         flags.append('--reproject')
 
     if nproc is not None:
-        flags.append('--nproc=%i' % nproc)
+        flags.append(f'--nproc={nproc}')
 
     result = runner.invoke(cli.cli, ['optimize-rasters', input_pattern, '-o', str(tmpdir), *flags])
 

--- a/tests/scripts/test_optimize_rasters.py
+++ b/tests/scripts/test_optimize_rasters.py
@@ -122,6 +122,11 @@ def test_optimize_rasters_invalid(tmpdir):
     assert result.exit_code != 0
     assert 'not a file' in result.output
 
+    result = runner.invoke(cli.cli, ['optimize-rasters', "not-a-file", '-o', str(tmpdir),
+                                     '--overwrite', '--skip-existing'])
+    assert result.exit_code != 0
+    assert 'mutually exclusive' in result.output
+
 
 def test_optimize_rasters_multiband(tmpdir, unoptimized_raster_file):
     from terracotta.scripts import cli

--- a/tests/scripts/test_optimize_rasters.py
+++ b/tests/scripts/test_optimize_rasters.py
@@ -36,9 +36,9 @@ def tiny_raster_file(unoptimized_raster_file, tmpdir_factory):
 @pytest.mark.parametrize('in_memory', [True, None, False])
 @pytest.mark.parametrize('reproject', [True, False])
 @pytest.mark.parametrize('compression', ['auto', 'lzw', 'none'])
-@pytest.mark.parametrize('cores', [None, 1, 2, -1])
+@pytest.mark.parametrize('nproc', [None, 1, 2, -1])
 def test_optimize_rasters(unoptimized_raster_file, tmpdir, in_memory,
-                          reproject, compression, cores):
+                          reproject, compression, nproc):
     from terracotta.cog import validate
     from terracotta.scripts import cli
 
@@ -55,8 +55,8 @@ def test_optimize_rasters(unoptimized_raster_file, tmpdir, in_memory,
     if reproject:
         flags.append('--reproject')
 
-    if cores is not None:
-        flags.append('--cores=%i' % cores)
+    if nproc is not None:
+        flags.append('--nproc=%i' % nproc)
 
     result = runner.invoke(cli.cli, ['optimize-rasters', input_pattern, '-o', str(tmpdir), *flags])
 


### PR DESCRIPTION
Use a `multiprocessing.Pool` to optimize raster files in parallel (each raster file is applied individually). Closes #55 

Currently uses `multiprocessing.cpu_count()` number of threads. This seems to be the number of logical (hyper-threading) cores: I'm unsure whether the number of physical cores might be preferable.

Currently has some caveats:
1: The sub-progress bars are removed, such that only the overall progress is shown.
(And the filename postfix is now showing the just-completed file, rather than the currently-being-processed file).

2: When raising an exception because optimized files already exists (and neither  `--overwrite` nor `--skip-existing` flags are set), the entire trace-stack is now shown, where it previously just showed a nice little message.

3: The `test_reoptimize` test in `tests/scripts/test_optimize_rasters.py` fails. Not because the code performs wrongly, but because of the way exceptions inside threads are handled.
When submitting a task to the `Pool`, an `error_callback` function is given, which receives any errors which occurs in the thread (and handles them in the main-thread). But apparently pytest recognizes that an error has been thrown inside the threads, and fails the test based on that.
If a preprocessed file already exists, and `terracotta optimize-rasters` is run without `--overwrite` or `--skip-existing` flags, then the expected behaviour is to throw an exception. But somehow pytest expects the exception to be raised differently, or something like that? 
And I can't figure out how to make the test accept the new exception flow, such that the test just tests whether the code handles preexisting optimized files properly, and not where/how the exception is raised.