### PR TITLE
Require pymysql>=1.0.0, which has a context managed connection

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,12 +94,12 @@ setup(
             'sphinx',
             'sphinx_autodoc_typehints',
             'sphinx-click',
-            'pymysql<0.10'
+            'pymysql>=1.0.0'
         ],
         'recommended': [
             'colorlog',
             'crick',
-            'pymysql<0.10'
+            'pymysql>=1.0.0'
         ]
     },
     # CLI


### PR DESCRIPTION
Closes #185, as pymysql version >=1.0 has a context managed connection. See https://github.com/PyMySQL/PyMySQL/blob/main/pymysql/connections.py#L354