### PR TITLE
Introduce multiqueries for dataset lookup #33

### DIFF
--- a/terracotta/drivers/base.py
+++ b/terracotta/drivers/base.py
@@ -3,7 +3,7 @@
 Base class for drivers.
 """
 
-from typing import Callable, Mapping, Any, Tuple, Sequence, Dict, Union, TypeVar
+from typing import Callable, List, Mapping, Any, Tuple, Sequence, Dict, Union, TypeVar
 from abc import ABC, abstractmethod
 from collections import OrderedDict
 import functools
@@ -82,7 +82,7 @@ class Driver(ABC):
         pass
 
     @abstractmethod
-    def get_datasets(self, where: Mapping[str, str] = None,
+    def get_datasets(self, where: Mapping[str, List[str]] = None,
                      page: int = 0, limit: int = None) -> Dict[Tuple[str, ...], Any]:
         # Get all known dataset key combinations matching the given constraints,
         # and a handle to retrieve the data (driver dependent)

--- a/terracotta/drivers/base.py
+++ b/terracotta/drivers/base.py
@@ -82,7 +82,7 @@ class Driver(ABC):
         pass
 
     @abstractmethod
-    def get_datasets(self, where: Mapping[str, List[str]] = None,
+    def get_datasets(self, where: Mapping[str, Union[str, List[str]]] = None,
                      page: int = 0, limit: int = None) -> Dict[Tuple[str, ...], Any]:
         # Get all known dataset key combinations matching the given constraints,
         # and a handle to retrieve the data (driver dependent)

--- a/terracotta/drivers/mysql.py
+++ b/terracotta/drivers/mysql.py
@@ -9,7 +9,6 @@ from typing import (List, Tuple, Dict, Iterator, Sequence, Union,
 from collections import OrderedDict
 import contextlib
 from contextlib import AbstractContextManager
-import itertools
 import re
 import json
 import urllib.parse as urlparse

--- a/terracotta/drivers/mysql.py
+++ b/terracotta/drivers/mysql.py
@@ -336,7 +336,7 @@ class MySQLDriver(RasterDriver):
     @trace('get_datasets')
     @requires_connection
     @convert_exceptions('Could not retrieve datasets')
-    def get_datasets(self, where: Mapping[str, List[str]] = None,
+    def get_datasets(self, where: Mapping[str, Union[str, List[str]]] = None,
                      page: int = 0, limit: int = None) -> Dict[Tuple[str, ...], str]:
         cursor = self._cursor
 
@@ -355,6 +355,7 @@ class MySQLDriver(RasterDriver):
             if not all(key in self.key_names for key in where.keys()):
                 raise exceptions.InvalidKeyError('Encountered unrecognized keys in '
                                                  'where clause')
+            where = {key: value if isinstance(value, list) else [value] for key, value in where.items()}
             conditions = ['(%s)' % ' OR '.join([f'{key}=%s']*len(value)) for key, value in where.items()]
             values = list(itertools.chain(*where.values()))
             where_fragment = ' AND '.join(conditions)

--- a/terracotta/drivers/mysql.py
+++ b/terracotta/drivers/mysql.py
@@ -355,8 +355,14 @@ class MySQLDriver(RasterDriver):
             if not all(key in self.key_names for key in where.keys()):
                 raise exceptions.InvalidKeyError('Encountered unrecognized keys in '
                                                  'where clause')
-            where = {key: value if isinstance(value, list) else [value] for key, value in where.items()}
-            conditions = ['(%s)' % ' OR '.join([f'{key}=%s']*len(value)) for key, value in where.items()]
+            where = {
+                key: value if isinstance(value, list) else [value]
+                for key, value in where.items()
+            }
+            conditions = [
+                '(%s)' % ' OR '.join([f'{key}=%s'] * len(value))
+                for key, value in where.items()
+            ]
             values = list(itertools.chain(*where.values()))
             where_fragment = ' AND '.join(conditions)
             cursor.execute(

--- a/terracotta/drivers/mysql.py
+++ b/terracotta/drivers/mysql.py
@@ -355,16 +355,14 @@ class MySQLDriver(RasterDriver):
             if not all(key in self.key_names for key in where.keys()):
                 raise exceptions.InvalidKeyError('Encountered unrecognized keys in '
                                                  'where clause')
-            where = {
-                key: value if isinstance(value, list) else [value]
-                for key, value in where.items()
-            }
-            conditions = [
-                '(%s)' % ' OR '.join([f'{key}=%s'] * len(value))
-                for key, value in where.items()
-            ]
-            values = list(itertools.chain(*where.values()))
-            where_fragment = ' AND '.join(conditions)
+            conditions = []
+            values = []
+            for key, value in where.items():
+                if isinstance(value, str):
+                    value = [value]
+                values.extend(value)
+                conditions.append(' OR '.join([f'{key}=%s'] * len(value)))
+            where_fragment = ' AND '.join([f'({condition})' for condition in conditions])
             cursor.execute(
                 f'SELECT * FROM datasets WHERE {where_fragment} {order_fragment} {page_fragment}',
                 values

--- a/terracotta/drivers/raster_base.py
+++ b/terracotta/drivers/raster_base.py
@@ -130,7 +130,7 @@ class RasterDriver(Driver):
 
     # specify signature and docstring for get_datasets
     @abstractmethod
-    def get_datasets(self, where: Mapping[str, str] = None,
+    def get_datasets(self, where: Mapping[str, List[str]] = None,
                      page: int = 0, limit: int = None) -> Dict[Tuple[str, ...], str]:
         """Retrieve keys and file paths of datasets.
 

--- a/terracotta/drivers/raster_base.py
+++ b/terracotta/drivers/raster_base.py
@@ -130,7 +130,7 @@ class RasterDriver(Driver):
 
     # specify signature and docstring for get_datasets
     @abstractmethod
-    def get_datasets(self, where: Mapping[str, List[str]] = None,
+    def get_datasets(self, where: Mapping[str, Union[str, List[str]]] = None,
                      page: int = 0, limit: int = None) -> Dict[Tuple[str, ...], str]:
         """Retrieve keys and file paths of datasets.
 

--- a/terracotta/drivers/sqlite.py
+++ b/terracotta/drivers/sqlite.py
@@ -4,7 +4,6 @@ SQLite-backed raster driver. Metadata is stored in an SQLite database, raster da
 to be present on disk.
 """
 
-import itertools
 from typing import Any, List, Sequence, Mapping, Tuple, Union, Iterator, Dict, cast
 import os
 import contextlib

--- a/terracotta/drivers/sqlite.py
+++ b/terracotta/drivers/sqlite.py
@@ -253,16 +253,14 @@ class SQLiteDriver(RasterDriver):
             if not all(key in self.key_names for key in where.keys()):
                 raise exceptions.InvalidKeyError('Encountered unrecognized keys in '
                                                  'where clause')
-            where = {
-                key: value if isinstance(value, list) else [value]
-                for key, value in where.items()
-            }
-            conditions = [
-                '(%s)' % ' OR '.join([f'{key}=?'] * len(value))
-                for key, value in where.items()
-            ]
-            values = list(itertools.chain(*where.values()))
-            where_fragment = ' AND '.join(conditions)
+            conditions = []
+            values = []
+            for key, value in where.items():
+                if isinstance(value, str):
+                    value = [value]
+                values.extend(value)
+                conditions.append(' OR '.join([f'{key}=?'] * len(value)))
+            where_fragment = ' AND '.join([f'({condition})' for condition in conditions])
             rows = conn.execute(
                 f'SELECT * FROM datasets WHERE {where_fragment} {order_fragment} {page_fragment}',
                 values

--- a/terracotta/drivers/sqlite.py
+++ b/terracotta/drivers/sqlite.py
@@ -253,8 +253,14 @@ class SQLiteDriver(RasterDriver):
             if not all(key in self.key_names for key in where.keys()):
                 raise exceptions.InvalidKeyError('Encountered unrecognized keys in '
                                                  'where clause')
-            where = {key: value if isinstance(value, list) else [value] for key, value in where.items()}
-            conditions = ['(%s)' % ' OR '.join([f'{key}=?']*len(value)) for key, value in where.items()]
+            where = {
+                key: value if isinstance(value, list) else [value]
+                for key, value in where.items()
+            }
+            conditions = [
+                '(%s)' % ' OR '.join([f'{key}=?'] * len(value))
+                for key, value in where.items()
+            ]
             values = list(itertools.chain(*where.values()))
             where_fragment = ' AND '.join(conditions)
             rows = conn.execute(

--- a/terracotta/drivers/sqlite.py
+++ b/terracotta/drivers/sqlite.py
@@ -234,7 +234,7 @@ class SQLiteDriver(RasterDriver):
     @trace('get_datasets')
     @requires_connection
     @convert_exceptions('Could not retrieve datasets')
-    def get_datasets(self, where: Mapping[str, List[str]] = None,
+    def get_datasets(self, where: Mapping[str, Union[str, List[str]]] = None,
                      page: int = 0, limit: int = None) -> Dict[Tuple[str, ...], str]:
         conn = self._connection
 
@@ -253,6 +253,7 @@ class SQLiteDriver(RasterDriver):
             if not all(key in self.key_names for key in where.keys()):
                 raise exceptions.InvalidKeyError('Encountered unrecognized keys in '
                                                  'where clause')
+            where = {key: value if isinstance(value, list) else [value] for key, value in where.items()}
             conditions = ['(%s)' % ' OR '.join([f'{key}=?']*len(value)) for key, value in where.items()]
             values = list(itertools.chain(*where.values()))
             where_fragment = ' AND '.join(conditions)

--- a/terracotta/handlers/datasets.py
+++ b/terracotta/handlers/datasets.py
@@ -3,7 +3,7 @@
 Handle /datasets API endpoint.
 """
 
-from typing import Mapping, List  # noqa: F401
+from typing import Mapping, List, Union  # noqa: F401
 from collections import OrderedDict
 import re
 
@@ -21,8 +21,10 @@ def datasets(some_keys: Mapping[str, str] = None,
     # TODO: Use some proper parsing
     if some_keys is not None:
         for key, value in some_keys.items():
-            if re.match('^\[.*\]$', value):
-                some_keys[key] = value[1:-1].split(',')
+            if re.match(r'^\[.*\]$', value):
+                # This changes the typing of `some_keys`, as expected by `driver.get_datasets`,
+                # but that makes mypy worried; hence the rather ugly # type: ignore
+                some_keys[key] = value[1:-1].split(',')  # type: ignore
 
     with driver.connect():
         dataset_keys = driver.get_datasets(

--- a/terracotta/handlers/datasets.py
+++ b/terracotta/handlers/datasets.py
@@ -12,19 +12,11 @@ from terracotta.profile import trace
 
 
 @trace('datasets_handler')
-def datasets(some_keys: Mapping[str, str] = None,
+def datasets(some_keys: Mapping[str, Union[str, List[str]]] = None,
              page: int = 0, limit: int = 500) -> 'List[OrderedDict[str, str]]':
     """List all available key combinations"""
     settings = get_settings()
     driver = get_driver(settings.DRIVER_PATH, provider=settings.DRIVER_PROVIDER)
-
-    # TODO: Use some proper parsing
-    if some_keys is not None:
-        for key, value in some_keys.items():
-            if re.match(r'^\[.*\]$', value):
-                # This changes the typing of `some_keys`, as expected by `driver.get_datasets`,
-                # but that makes mypy worried; hence the rather ugly # type: ignore
-                some_keys[key] = value[1:-1].split(',')  # type: ignore
 
     with driver.connect():
         dataset_keys = driver.get_datasets(

--- a/terracotta/handlers/datasets.py
+++ b/terracotta/handlers/datasets.py
@@ -5,6 +5,7 @@ Handle /datasets API endpoint.
 
 from typing import Mapping, List  # noqa: F401
 from collections import OrderedDict
+import re
 
 from terracotta import get_settings, get_driver
 from terracotta.profile import trace
@@ -16,6 +17,14 @@ def datasets(some_keys: Mapping[str, str] = None,
     """List all available key combinations"""
     settings = get_settings()
     driver = get_driver(settings.DRIVER_PATH, provider=settings.DRIVER_PROVIDER)
+
+    # TODO: Use some proper parsing
+    if some_keys is not None:
+        for key, value in some_keys.items():
+            if re.match('^\[.*\]$', value):
+                some_keys[key] = value[1:-1].split(',')
+            else:
+                some_keys[key] = [value]
 
     with driver.connect():
         dataset_keys = driver.get_datasets(

--- a/terracotta/handlers/datasets.py
+++ b/terracotta/handlers/datasets.py
@@ -5,7 +5,6 @@ Handle /datasets API endpoint.
 
 from typing import Mapping, List, Union  # noqa: F401
 from collections import OrderedDict
-import re
 
 from terracotta import get_settings, get_driver
 from terracotta.profile import trace

--- a/terracotta/handlers/datasets.py
+++ b/terracotta/handlers/datasets.py
@@ -23,8 +23,6 @@ def datasets(some_keys: Mapping[str, str] = None,
         for key, value in some_keys.items():
             if re.match('^\[.*\]$', value):
                 some_keys[key] = value[1:-1].split(',')
-            else:
-                some_keys[key] = [value]
 
     with driver.connect():
         dataset_keys = driver.get_datasets(

--- a/terracotta/server/datasets.py
+++ b/terracotta/server/datasets.py
@@ -33,7 +33,6 @@ class DatasetOptionSchema(Schema):
         # Create lists of values supplied as stringified lists
         for key, value in data.items():
             if isinstance(value, str) and re.match(r'^\[.*\]$', value):
-                print(value)
                 data[key] = value[1:-1].split(',')
         return data
 

--- a/terracotta/server/datasets.py
+++ b/terracotta/server/datasets.py
@@ -4,7 +4,8 @@ Flask route to handle /datasets calls.
 """
 
 from flask import request, jsonify, Response
-from marshmallow import Schema, fields, validate, INCLUDE
+from marshmallow import Schema, fields, validate, INCLUDE, post_load
+import re
 
 from terracotta.server.flask_api import METADATA_API
 
@@ -25,6 +26,15 @@ class DatasetOptionSchema(Schema):
     page = fields.Integer(
         missing=0, description='Current dataset page', validate=validate.Range(min=0)
     )
+
+    @post_load
+    def list_items(self, data, **kwargs):
+        # Create lists of values supplied as stringified lists
+        for key, value in data.items():
+            if isinstance(value, str) and re.match(r'^\[.*\]$', value):
+                print(value)
+                data[key] = value[1:-1].split(',')
+        return data
 
 
 class DatasetSchema(Schema):

--- a/terracotta/server/datasets.py
+++ b/terracotta/server/datasets.py
@@ -3,6 +3,7 @@
 Flask route to handle /datasets calls.
 """
 
+from typing import Any, Dict, List, Union
 from flask import request, jsonify, Response
 from marshmallow import Schema, fields, validate, INCLUDE, post_load
 import re
@@ -28,7 +29,7 @@ class DatasetOptionSchema(Schema):
     )
 
     @post_load
-    def list_items(self, data, **kwargs):
+    def list_items(self, data: Dict[str, Any], **kwargs: Any) -> Dict[str, Union[str, List[str]]]:
         # Create lists of values supplied as stringified lists
         for key, value in data.items():
             if isinstance(value, str) and re.match(r'^\[.*\]$', value):

--- a/tests/server/test_flask_api.py
+++ b/tests/server/test_flask_api.py
@@ -98,6 +98,14 @@ def test_get_datasets_selective(client, use_testdb):
     assert rv.status_code == 200
     assert len(json.loads(rv.data)['datasets']) == 1
 
+    rv = client.get('/datasets?key1=[val21]')
+    assert rv.status_code == 200
+    assert len(json.loads(rv.data)['datasets']) == 3
+
+    rv = client.get('/datasets?key2=[val23,val24]&akey=x')
+    assert rv.status_code == 200
+    assert len(json.loads(rv.data)['datasets']) == 2
+
 
 def test_get_datasets_unknown_key(client, use_testdb):
     rv = client.get('/datasets?UNKNOWN=val21')


### PR DESCRIPTION
Make it possible to query datasets like `/datasets?year=[2016,2018]&band=02`. This closes #33.

The parsing of lists of values is implemented rather naively, but it works.

The `driver.get_datasets()` method now accepts `where: Mapping[str, Union[str, List[str]]]`. Handling both cases (conditions either string or list of strings) have introduced some somewhat convoluted code to create the SQL queries, but I think it's about as good as it gets without a larger rewrite.