### PR TITLE
Add writable flag to meta stores

### DIFF
--- a/terracotta/drivers/base_classes.py
+++ b/terracotta/drivers/base_classes.py
@@ -38,6 +38,7 @@ class MetaStore(ABC):
     Defines a common interface for all metadata backends.
     """
     _RESERVED_KEYS = ('limit', 'page')
+    WRITABLE: bool = True
 
     @property
     @abstractmethod

--- a/terracotta/drivers/base_classes.py
+++ b/terracotta/drivers/base_classes.py
@@ -24,7 +24,7 @@ def requires_writable(fun: Callable[..., T]) -> Callable[..., T]:
         if self._WRITABLE:
             return fun(self, *args, **kwargs)
         else:
-            raise exceptions.DatabaseNotWritable("Database not writable")
+            raise exceptions.DatabaseNotWritableError("Database not writable")
 
     return inner
 

--- a/terracotta/drivers/relational_meta_store.py
+++ b/terracotta/drivers/relational_meta_store.py
@@ -21,7 +21,8 @@ from sqlalchemy.engine.url import URL
 from terracotta import exceptions
 from terracotta.drivers.base_classes import (KeysType, MetaStore,
                                              MultiValueKeysType,
-                                             requires_connection)
+                                             requires_connection,
+                                             requires_writable)
 from terracotta.profile import trace
 
 _ERROR_ON_CONNECT = (
@@ -349,6 +350,7 @@ class RelationalMetaStore(MetaStore, ABC):
         return self._decode_data(encoded_data)
 
     @trace('insert')
+    @requires_writable
     @requires_connection
     @convert_exceptions('Could not write to database')
     def insert(
@@ -383,6 +385,7 @@ class RelationalMetaStore(MetaStore, ABC):
             )
 
     @trace('delete')
+    @requires_writable
     @requires_connection
     @convert_exceptions('Could not write to database')
     def delete(self, keys: KeysType) -> None:

--- a/terracotta/drivers/relational_meta_store.py
+++ b/terracotta/drivers/relational_meta_store.py
@@ -182,6 +182,7 @@ class RelationalMetaStore(MetaStore, ABC):
         version = self.connection.execute(stmt).scalar()
         return version
 
+    @requires_writable
     @convert_exceptions('Could not create database')
     def create(self, keys: Sequence[str], key_descriptions: Mapping[str, str] = None) -> None:
         """Create and initialize database with empty tables.

--- a/terracotta/drivers/sqlite_remote_meta_store.py
+++ b/terracotta/drivers/sqlite_remote_meta_store.py
@@ -70,7 +70,7 @@ class RemoteSQLiteMetaStore(SQLiteMetaStore):
     Warning:
 
         This driver is read-only. Any attempts to use the create, insert, or delete methods
-        will throw a DatabaseNotWritable.
+        will throw a DatabaseNotWritableError.
 
     """
 
@@ -135,6 +135,7 @@ class RemoteSQLiteMetaStore(SQLiteMetaStore):
         self._update_db(self._remote_path, self._local_path)
         super()._connection_callback()
 
+    # Always raises DatabaseNotWritableError
     @requires_writable
     def create(self, *args: Any, **kwargs: Any) -> None:
         pass

--- a/terracotta/drivers/sqlite_remote_meta_store.py
+++ b/terracotta/drivers/sqlite_remote_meta_store.py
@@ -73,6 +73,8 @@ class RemoteSQLiteMetaStore(SQLiteMetaStore):
 
     """
 
+    WRITEABLE: bool = False
+
     def __init__(self, remote_path: Union[str, Path]) -> None:
         """Initialize the RemoteSQLiteDriver.
 

--- a/terracotta/drivers/sqlite_remote_meta_store.py
+++ b/terracotta/drivers/sqlite_remote_meta_store.py
@@ -11,11 +11,10 @@ import tempfile
 import time
 import urllib.parse as urlparse
 from pathlib import Path
-from typing import Any, Iterator, Union
+from typing import Iterator, Union
 
 from terracotta import exceptions, get_settings
 from terracotta.drivers.sqlite_meta_store import SQLiteMetaStore
-from terracotta.drivers.base_classes import requires_writable
 from terracotta.profile import trace
 
 logger = logging.getLogger(__name__)
@@ -134,19 +133,6 @@ class RemoteSQLiteMetaStore(SQLiteMetaStore):
     def _connection_callback(self) -> None:
         self._update_db(self._remote_path, self._local_path)
         super()._connection_callback()
-
-    # Always raises DatabaseNotWritableError
-    @requires_writable
-    def create(self, *args: Any, **kwargs: Any) -> None:
-        pass
-
-    @requires_writable
-    def insert(self, *args: Any, **kwargs: Any) -> None:
-        pass
-
-    @requires_writable
-    def delete(self, *args: Any, **kwargs: Any) -> None:
-        pass
 
     def __del__(self) -> None:
         """Clean up temporary database upon exit"""

--- a/terracotta/drivers/sqlite_remote_meta_store.py
+++ b/terracotta/drivers/sqlite_remote_meta_store.py
@@ -15,6 +15,7 @@ from typing import Any, Iterator, Union
 
 from terracotta import exceptions, get_settings
 from terracotta.drivers.sqlite_meta_store import SQLiteMetaStore
+from terracotta.drivers.base_classes import requires_writable
 from terracotta.profile import trace
 
 logger = logging.getLogger(__name__)
@@ -69,11 +70,11 @@ class RemoteSQLiteMetaStore(SQLiteMetaStore):
     Warning:
 
         This driver is read-only. Any attempts to use the create, insert, or delete methods
-        will throw a NotImplementedError.
+        will throw a DatabaseNotWritable.
 
     """
 
-    WRITEABLE: bool = False
+    _WRITABLE: bool = False
 
     def __init__(self, remote_path: Union[str, Path]) -> None:
         """Initialize the RemoteSQLiteDriver.
@@ -134,14 +135,17 @@ class RemoteSQLiteMetaStore(SQLiteMetaStore):
         self._update_db(self._remote_path, self._local_path)
         super()._connection_callback()
 
+    @requires_writable
     def create(self, *args: Any, **kwargs: Any) -> None:
-        raise NotImplementedError('Remote SQLite databases are read-only')
+        pass
 
+    @requires_writable
     def insert(self, *args: Any, **kwargs: Any) -> None:
-        raise NotImplementedError('Remote SQLite databases are read-only')
+        pass
 
+    @requires_writable
     def delete(self, *args: Any, **kwargs: Any) -> None:
-        raise NotImplementedError('Remote SQLite databases are read-only')
+        pass
 
     def __del__(self) -> None:
         """Clean up temporary database upon exit"""

--- a/terracotta/drivers/terracotta_driver.py
+++ b/terracotta/drivers/terracotta_driver.py
@@ -5,8 +5,7 @@ The driver to interact with.
 
 import contextlib
 from collections import OrderedDict
-import functools
-from typing import (Any, Callable, Collection, Dict, List, Mapping,
+from typing import (Any, Collection, Dict, List, Mapping,
                     Optional, Sequence, Tuple, TypeVar, Union)
 
 import terracotta
@@ -18,17 +17,6 @@ from terracotta.drivers.base_classes import (KeysType, MetaStore,
 ExtendedKeysType = Union[Sequence[str], Mapping[str, str]]
 ExtendedMultiValueKeysType = Union[Sequence[str], Mapping[str, Union[str, List[str]]]]
 T = TypeVar('T')
-
-
-def requires_writable(fun: Callable[..., T]) -> Callable[..., T]:
-    @functools.wraps(fun)
-    def inner(self: "TerracottaDriver", *args: Any, **kwargs: Any) -> T:
-        if self.meta_store.WRITABLE:
-            return fun(self, *args, **kwargs)
-        else:
-            raise exceptions.DatabaseNotWritable("Database not writable")
-
-    return inner
 
 
 def squeeze(iterable: Collection[T]) -> T:
@@ -70,7 +58,6 @@ class TerracottaDriver:
         """
         return self.meta_store.key_names
 
-    @requires_writable
     def create(self, keys: Sequence[str], *,
                key_descriptions: Mapping[str, str] = None) -> None:
         """Create a new, empty metadata store.
@@ -183,16 +170,19 @@ class TerracottaDriver:
             path = squeeze(dataset.values())
             metadata = self.compute_metadata(path, max_shape=self.LAZY_LOADING_MAX_SHAPE)
 
-            if self.meta_store.WRITABLE:
+            try:
                 self.insert(keys, path, metadata=metadata)
 
                 # ensure standardized/consistent output (types and floating point precision)
                 metadata = self.meta_store.get_metadata(keys)
                 assert metadata is not None
+            except exceptions.DatabaseNotWritable as exc:
+                raise exceptions.DatabaseNotWritable(
+                    "Lazy loading requires a writable database"
+                ) from exc
 
         return metadata
 
-    @requires_writable
     @requires_connection
     def insert(
         self, keys: ExtendedKeysType,
@@ -227,7 +217,6 @@ class TerracottaDriver:
             metadata=metadata
         )
 
-    @requires_writable
     @requires_connection
     def delete(self, keys: ExtendedKeysType) -> None:
         """Remove a dataset from the meta store.

--- a/terracotta/drivers/terracotta_driver.py
+++ b/terracotta/drivers/terracotta_driver.py
@@ -6,8 +6,8 @@ The driver to interact with.
 import contextlib
 from collections import OrderedDict
 import functools
-from typing import (Any, Callable, Collection, Dict, List, Mapping, Optional, Sequence, Tuple, TypeVar,
-                    Union)
+from typing import (Any, Callable, Collection, Dict, List, Mapping,
+                    Optional, Sequence, Tuple, TypeVar, Union)
 
 import terracotta
 from terracotta import exceptions
@@ -21,7 +21,7 @@ T = TypeVar('T')
 
 
 def requires_writable(
-    fun: Callable[..., T] = None
+    fun: Callable[..., T]
 ) -> Callable[..., T]:
     @functools.wraps(fun)
     def inner(self: "TerracottaDriver", *args: Any, **kwargs: Any) -> T:

--- a/terracotta/drivers/terracotta_driver.py
+++ b/terracotta/drivers/terracotta_driver.py
@@ -172,14 +172,14 @@ class TerracottaDriver:
 
             try:
                 self.insert(keys, path, metadata=metadata)
-
-                # ensure standardized/consistent output (types and floating point precision)
-                metadata = self.meta_store.get_metadata(keys)
-                assert metadata is not None
-            except exceptions.DatabaseNotWritable as exc:
-                raise exceptions.DatabaseNotWritable(
+            except exceptions.DatabaseNotWritableError as exc:
+                raise exceptions.DatabaseNotWritableError(
                     "Lazy loading requires a writable database"
                 ) from exc
+
+            # ensure standardized/consistent output (types and floating point precision)
+            metadata = self.meta_store.get_metadata(keys)
+            assert metadata is not None
 
         return metadata
 

--- a/terracotta/drivers/terracotta_driver.py
+++ b/terracotta/drivers/terracotta_driver.py
@@ -20,12 +20,9 @@ ExtendedMultiValueKeysType = Union[Sequence[str], Mapping[str, Union[str, List[s
 T = TypeVar('T')
 
 
-def requires_writable(
-    fun: Callable[..., T]
-) -> Callable[..., T]:
+def requires_writable(fun: Callable[..., T]) -> Callable[..., T]:
     @functools.wraps(fun)
     def inner(self: "TerracottaDriver", *args: Any, **kwargs: Any) -> T:
-        assert fun is not None
         if self.meta_store.WRITABLE:
             return fun(self, *args, **kwargs)
         else:

--- a/terracotta/exceptions.py
+++ b/terracotta/exceptions.py
@@ -24,5 +24,9 @@ class InvalidDatabaseError(Exception):
     pass
 
 
+class DatabaseNotWritable(Exception):
+    pass
+
+
 class PerformanceWarning(UserWarning):
     pass

--- a/terracotta/exceptions.py
+++ b/terracotta/exceptions.py
@@ -24,7 +24,7 @@ class InvalidDatabaseError(Exception):
     pass
 
 
-class DatabaseNotWritable(Exception):
+class DatabaseNotWritableError(Exception):
     pass
 
 

--- a/terracotta/server/flask_api.py
+++ b/terracotta/server/flask_api.py
@@ -63,6 +63,14 @@ def _setup_error_handlers(app: Flask) -> None:
 
     register_error_handler(exceptions.DatasetNotFoundError, handle_dataset_not_found_error)
 
+    def handle_database_not_writable_error(exc: Exception) -> Any:
+        # database not writable -> 403
+        if current_app.debug:
+            raise exc
+        return _abort(403, str(exc))
+
+    register_error_handler(exceptions.DatabaseNotWritableError, handle_database_not_writable_error)
+
     def handle_marshmallow_validation_error(exc: Exception) -> Any:
         # wrong query arguments -> 400
         if current_app.debug:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -353,9 +353,9 @@ def use_non_writable_testdb(testdb, monkeypatch, raster_file):
     with driver.connect():
         driver.insert(('first', 'second', 'third'), str(raster_file), skip_metadata=True)
 
-    driver.meta_store._WRITABLE = False
-    yield
-    driver.meta_store._WRITABLE = True
+    with monkeypatch.context() as m:
+        m.setattr(driver.meta_store, "_WRITABLE", False)
+        yield
 
     driver.delete(('first', 'second', 'third'))
 

--- a/tests/drivers/test_raster_drivers.py
+++ b/tests/drivers/test_raster_drivers.py
@@ -5,6 +5,8 @@ import time
 
 import numpy as np
 
+from terracotta import exceptions
+
 DRIVERS = ['sqlite', 'mysql']
 METADATA_KEYS = ('bounds', 'range', 'mean', 'stdev', 'percentiles', 'metadata')
 
@@ -142,6 +144,22 @@ def test_lazy_loading(driver_path, provider, raster_file):
     data2 = db.get_metadata({'some': 'some', 'keynames': 'other_value'})
     assert set(data1.keys()) == set(data2.keys())
     assert all(np.all(data1[k] == data2[k]) for k in data1.keys())
+
+
+@pytest.mark.parametrize('provider', DRIVERS)
+def test_non_writable_lazy_loading(driver_path, provider, raster_file):
+    from terracotta import drivers
+    db = drivers.get_driver(driver_path, provider=provider)
+    keys = ('some', 'keynames')
+
+    db.create(keys)
+    db.insert(['some', 'value'], str(raster_file), skip_metadata=True)
+
+    # Manually set the meta store to un-writable
+    db.meta_store._WRITABLE = False
+
+    with pytest.raises(exceptions.DatabaseNotWritableError):
+        db.get_metadata(['some', 'value'])
 
 
 @pytest.mark.parametrize('provider', DRIVERS)

--- a/tests/drivers/test_sqlite_remote.py
+++ b/tests/drivers/test_sqlite_remote.py
@@ -4,27 +4,13 @@ Tests that apply to all drivers go to test_drivers.py.
 """
 
 import os
-import tempfile
 import time
-import uuid
-from pathlib import Path
 
 import pytest
 
 from terracotta import exceptions
 
-boto3 = pytest.importorskip('boto3')
 moto = pytest.importorskip('moto')
-
-
-@pytest.fixture(autouse=True)
-def mock_aws_env(monkeypatch):
-    with monkeypatch.context() as m:
-        m.setenv('AWS_DEFAULT_REGION', 'us-east-1')
-        m.setenv('AWS_ACCESS_KEY_ID', 'FakeKey')
-        m.setenv('AWS_SECRET_ACCESS_KEY', 'FakeSecretKey')
-        m.setenv('AWS_SESSION_TOKEN', 'FakeSessionToken')
-        yield
 
 
 class Timer:
@@ -41,38 +27,8 @@ class Timer:
         self.time += 1
 
 
-@pytest.fixture()
-def s3_db_factory(tmpdir):
-    bucketname = str(uuid.uuid4())
-
-    def _s3_db_factory(keys, datasets=None):
-        from terracotta import get_driver
-
-        with tempfile.TemporaryDirectory() as tmpdir:
-            dbfile = Path(tmpdir) / 'tc.sqlite'
-            driver = get_driver(dbfile)
-            driver.create(keys)
-
-            if datasets:
-                for keys, path in datasets.items():
-                    driver.insert(keys, path)
-
-            with open(dbfile, 'rb') as f:
-                db_bytes = f.read()
-
-        conn = boto3.resource('s3')
-        conn.create_bucket(Bucket=bucketname)
-
-        s3 = boto3.client('s3')
-        s3.put_object(Bucket=bucketname, Key='tc.sqlite', Body=db_bytes)
-
-        return f's3://{bucketname}/tc.sqlite'
-
-    return _s3_db_factory
-
-
 @moto.mock_s3
-def test_remote_database(s3_db_factory):
+def test_remote_database(s3_db_factory, mock_aws_env):
     keys = ('some', 'keys')
     dbpath = s3_db_factory(keys)
 
@@ -91,7 +47,7 @@ def test_invalid_url():
 
 
 @moto.mock_s3
-def test_nonexisting_url():
+def test_nonexisting_url(mock_aws_env):
     from terracotta import exceptions, get_driver
     driver = get_driver('s3://foo/db.sqlite')
     with pytest.raises(exceptions.InvalidDatabaseError):
@@ -100,7 +56,7 @@ def test_nonexisting_url():
 
 
 @moto.mock_s3
-def test_remote_database_cache(s3_db_factory, raster_file, monkeypatch):
+def test_remote_database_cache(s3_db_factory, raster_file, mock_aws_env):
     keys = ('some', 'keys')
     dbpath = s3_db_factory(keys)
 
@@ -136,7 +92,7 @@ def test_remote_database_cache(s3_db_factory, raster_file, monkeypatch):
 
 
 @moto.mock_s3
-def test_immutability(s3_db_factory, raster_file):
+def test_immutability(s3_db_factory, raster_file, mock_aws_env):
     keys = ('some', 'keys')
     dbpath = s3_db_factory(keys, datasets={('some', 'value'): str(raster_file)})
 
@@ -155,7 +111,7 @@ def test_immutability(s3_db_factory, raster_file):
 
 
 @moto.mock_s3
-def test_destructor(s3_db_factory, raster_file, capsys):
+def test_destructor(s3_db_factory, raster_file, capsys, mock_aws_env):
     keys = ('some', 'keys')
     dbpath = s3_db_factory(keys, datasets={('some', 'value'): str(raster_file)})
 

--- a/tests/drivers/test_sqlite_remote.py
+++ b/tests/drivers/test_sqlite_remote.py
@@ -11,6 +11,8 @@ from pathlib import Path
 
 import pytest
 
+from terracotta import exceptions
+
 boto3 = pytest.importorskip('boto3')
 moto = pytest.importorskip('moto')
 
@@ -142,13 +144,13 @@ def test_immutability(s3_db_factory, raster_file):
 
     driver = get_driver(dbpath)
 
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(exceptions.DatabaseNotWritable):
         driver.create(keys)
 
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(exceptions.DatabaseNotWritable):
         driver.insert(('some', 'value'), str(raster_file))
 
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(exceptions.DatabaseNotWritable):
         driver.delete(('some', 'value'))
 
 

--- a/tests/drivers/test_sqlite_remote.py
+++ b/tests/drivers/test_sqlite_remote.py
@@ -144,13 +144,13 @@ def test_immutability(s3_db_factory, raster_file):
 
     driver = get_driver(dbpath)
 
-    with pytest.raises(exceptions.DatabaseNotWritable):
+    with pytest.raises(exceptions.DatabaseNotWritableError):
         driver.create(keys)
 
-    with pytest.raises(exceptions.DatabaseNotWritable):
+    with pytest.raises(exceptions.DatabaseNotWritableError):
         driver.insert(('some', 'value'), str(raster_file))
 
-    with pytest.raises(exceptions.DatabaseNotWritable):
+    with pytest.raises(exceptions.DatabaseNotWritableError):
         driver.delete(('some', 'value'))
 
 

--- a/tests/server/test_flask_api.py
+++ b/tests/server/test_flask_api.py
@@ -87,7 +87,7 @@ def test_debug_errors(debug_client, s3_db_factory, mock_aws_env, raster_file, ra
 
     with pytest.raises(exceptions.InvalidKeyError):
         debug_client.get('/metadata/ONLYONEKEY')
-    
+
     x, y, z = raster_file_xyz
 
     with pytest.raises(exceptions.InvalidArgumentsError):


### PR DESCRIPTION
Fixes #255

The `MetaStore` class is set to be writable by default:
https://github.com/DHI-GRAS/terracotta/blob/a3aedcbfcd95aed279dd9754434b6409462b4bc1/terracotta/drivers/base_classes.py#L41

Added a very thin decorator to throw the new `DatabaseNotWritable` exception:
https://github.com/DHI-GRAS/terracotta/blob/a3aedcbfcd95aed279dd9754434b6409462b4bc1/terracotta/drivers/terracotta_driver.py#L23-L34

And then we access the flag directly when getting metadata from the meta store:
https://github.com/DHI-GRAS/terracotta/blob/22353ca9c3f99dbe4cdb70b7497d93162827713a/terracotta/drivers/terracotta_driver.py#L187-L194

Me and @nickeopti were discussing whether or not it was cleanest to handle the database "writability" in `TerracottaDriver` or all meta stores individually. 