### PR TITLE
Re-add database user and password as settings, and rename from MYSQL_* to SQL_*

### DIFF
--- a/terracotta/config.py
+++ b/terracotta/config.py
@@ -176,7 +176,8 @@ class SettingSchema(Schema):
             if data.get(deprecated_field):
                 if not data.get(new_field):
                     warnings.warn(
-                        f'Setting TC_{deprecated_field} is deprecated and will be removed in the next major release. '
+                        f'Setting TC_{deprecated_field} is deprecated '
+                        'and will be removed in the next major release. '
                         f'Please use TC_{new_field} instead.',
                         exceptions.DeprecationWarning
                     )

--- a/terracotta/config.py
+++ b/terracotta/config.py
@@ -67,11 +67,11 @@ class TerracottaSettings(NamedTuple):
     #: CORS allowed origins for tiles endpoints
     ALLOWED_ORIGINS_TILES: List[str] = [r'http[s]?://(localhost|127\.0\.0\.1):*']
 
-    #: MySQL database username (if not given in driver path)
-    MYSQL_USER: Optional[str] = None
+    #: SQL database username (if not given in driver path)
+    SQL_USER: Optional[str] = None
 
-    #: MySQL database password (if not given in driver path)
-    MYSQL_PASSWORD: Optional[str] = None
+    #: SQL database password (if not given in driver path)
+    SQL_PASSWORD: Optional[str] = None
 
     #: Use a process pool for band retrieval in parallel
     USE_MULTIPROCESSING: bool = True
@@ -123,8 +123,8 @@ class SettingSchema(Schema):
     ALLOWED_ORIGINS_METADATA = fields.List(fields.String())
     ALLOWED_ORIGINS_TILES = fields.List(fields.String())
 
-    MYSQL_USER = fields.String()
-    MYSQL_PASSWORD = fields.String()
+    SQL_USER = fields.String()
+    SQL_PASSWORD = fields.String()
 
     USE_MULTIPROCESSING = fields.Boolean()
 

--- a/terracotta/config.py
+++ b/terracotta/config.py
@@ -86,10 +86,18 @@ class DeprecatedTerracottaSettings(NamedTuple):
     #: MySQL database password (if not given in driver path)
     MYSQL_PASSWORD: Optional[str] = None
 
+    #: PostgreSQL database username (if not given in driver path)
+    POSTGRESQL_USER: Optional[str] = None
+
+    #: PostgreSQL database password (if not given in driver path)
+    POSTGRESQL_PASSWORD: Optional[str] = None
+
 
 DEPRECATION_MAP: Dict[str, str] = {
     'MYSQL_USER': 'SQL_USER',
     'MYSQL_PASSWORD': 'SQL_PASSWORD',
+    'POSTGRESQL_USER': 'SQL_USER',
+    'POSTGRESQL_PASSWORD': 'SQL_PASSWORD',
 }
 
 AVAILABLE_SETTINGS: Tuple[str, ...] = (*TerracottaSettings._fields, *DeprecatedTerracottaSettings._fields)

--- a/terracotta/config.py
+++ b/terracotta/config.py
@@ -95,6 +95,7 @@ class TerracottaSettings(NamedTuple):
 AVAILABLE_SETTINGS: Tuple[str, ...] = TerracottaSettings._fields
 
 DEPRECATION_MAP: Dict[str, str] = {
+    # TODO: Remove in v0.8.0
     'MYSQL_USER': 'SQL_USER',
     'MYSQL_PASSWORD': 'SQL_PASSWORD',
     'POSTGRESQL_USER': 'SQL_USER',

--- a/terracotta/config.py
+++ b/terracotta/config.py
@@ -15,7 +15,7 @@ from terracotta import exceptions
 
 
 class TerracottaSettings(NamedTuple):
-    """Contains all non-deprecated settings for the current Terracotta instance."""
+    """Contains all settings for the current Terracotta instance."""
     #: Path to database
     DRIVER_PATH: str = ''
 

--- a/terracotta/config.py
+++ b/terracotta/config.py
@@ -176,7 +176,7 @@ class SettingSchema(Schema):
             if data.get(deprecated_field):
                 if not data.get(new_field):
                     warnings.warn(
-                        f'Setting TC_{deprecated_field} is being deprecated. '
+                        f'Setting TC_{deprecated_field} is deprecated and will be removed in the next major release. '
                         f'Please use TC_{new_field} instead.',
                         exceptions.DeprecationWarning
                     )

--- a/terracotta/config.py
+++ b/terracotta/config.py
@@ -89,7 +89,7 @@ class DeprecatedTerracottaSettings(NamedTuple):
 
 DEPRECATION_MAP: Dict[str, str] = {
     'MYSQL_USER': 'SQL_USER',
-    # 'MYSQL_PASSWORD': 'SQL_PASSWORD',
+    'MYSQL_PASSWORD': 'SQL_PASSWORD',
 }
 
 AVAILABLE_SETTINGS: Tuple[str, ...] = (*TerracottaSettings._fields, *DeprecatedTerracottaSettings._fields)

--- a/terracotta/config.py
+++ b/terracotta/config.py
@@ -138,15 +138,8 @@ class SettingSchema(Schema):
     ALLOWED_ORIGINS_METADATA = fields.List(fields.String())
     ALLOWED_ORIGINS_TILES = fields.List(fields.String())
 
-<<<<<<< HEAD
     SQL_USER = fields.String()
     SQL_PASSWORD = fields.String()
-=======
-    MYSQL_USER = fields.String()
-    MYSQL_PASSWORD = fields.String()
-    POSTGRESQL_USER = fields.String()
-    POSTGRESQL_PASSWORD = fields.String()
->>>>>>> main
 
     USE_MULTIPROCESSING = fields.Boolean()
 

--- a/terracotta/config.py
+++ b/terracotta/config.py
@@ -174,21 +174,17 @@ class SettingSchema(Schema):
     def handle_deprecated_fields(self, data: Dict[str, Any], **kwargs: Any) -> Dict[str, Any]:
         for deprecated_field, new_field in DEPRECATION_MAP.items():
             if data.get(deprecated_field):
+                warnings.warn(
+                    f'Setting TC_{deprecated_field} is deprecated '
+                    'and will be removed in the next major release. '
+                    f'Please use TC_{new_field} instead.',
+                    exceptions.DeprecationWarning
+                )
+
+                # Only use the mapping if the new field has not been set
                 if not data.get(new_field):
-                    warnings.warn(
-                        f'Setting TC_{deprecated_field} is deprecated '
-                        'and will be removed in the next major release. '
-                        f'Please use TC_{new_field} instead.',
-                        exceptions.DeprecationWarning
-                    )
                     data[new_field] = data[deprecated_field]
-                else:
-                    warnings.warn(
-                        f'Both the deprecated TC_{deprecated_field} setting '
-                        f'and its replacement TC_{new_field} is set: '
-                        'This may result in unexpected behaviour.',
-                        exceptions.DeprecationWarning
-                    )
+
         return data
 
     @post_load

--- a/terracotta/config.py
+++ b/terracotta/config.py
@@ -100,7 +100,10 @@ DEPRECATION_MAP: Dict[str, str] = {
     'POSTGRESQL_PASSWORD': 'SQL_PASSWORD',
 }
 
-AVAILABLE_SETTINGS: Tuple[str, ...] = (*TerracottaSettings._fields, *DeprecatedTerracottaSettings._fields)
+AVAILABLE_SETTINGS: Tuple[str, ...] = (
+    *TerracottaSettings._fields,
+    *DeprecatedTerracottaSettings._fields
+)
 
 
 def _is_writable(path: str) -> bool:

--- a/terracotta/config.py
+++ b/terracotta/config.py
@@ -168,7 +168,7 @@ class SettingSchema(Schema):
                         f'Could not parse value for key {var} as JSON: "{val}"'
                     ) from exc
         return data
-    
+
     @pre_load
     def handle_deprecated_fields(self, data: Dict[str, Any], **kwargs: Any) -> Dict[str, Any]:
         for deprecated_field, new_field in DEPRECATION_MAP.items():

--- a/terracotta/drivers/relational_meta_store.py
+++ b/terracotta/drivers/relational_meta_store.py
@@ -113,10 +113,11 @@ class RelationalMetaStore(MetaStore, ABC):
         if con_params.scheme != cls.SQL_DIALECT:
             raise ValueError(f'unsupported URL scheme "{con_params.scheme}"')
 
+        settings = terracotta.get_settings()
         url = URL.create(
             drivername=f'{cls.SQL_DIALECT}+{cls.SQL_DRIVER}',
-            username=con_params.username or terracotta.get_settings().SQL_USER,
-            password=con_params.password or terracotta.get_settings().SQL_PASSWORD,
+            username=con_params.username or settings.SQL_USER,
+            password=con_params.password or settings.SQL_PASSWORD,
             host=con_params.hostname,
             port=con_params.port,
             database=con_params.path[1:],  # remove leading '/' from urlparse

--- a/terracotta/drivers/relational_meta_store.py
+++ b/terracotta/drivers/relational_meta_store.py
@@ -115,8 +115,8 @@ class RelationalMetaStore(MetaStore, ABC):
 
         url = URL.create(
             drivername=f'{cls.SQL_DIALECT}+{cls.SQL_DRIVER}',
-            username=con_params.username,
-            password=con_params.password,
+            username=con_params.username or terracotta.get_settings().SQL_USER,
+            password=con_params.password or terracotta.get_settings().SQL_PASSWORD,
             host=con_params.hostname,
             port=con_params.port,
             database=con_params.path[1:],  # remove leading '/' from urlparse

--- a/terracotta/exceptions.py
+++ b/terracotta/exceptions.py
@@ -26,3 +26,6 @@ class InvalidDatabaseError(Exception):
 
 class PerformanceWarning(UserWarning):
     pass
+
+class DeprecationWarning(UserWarning):
+    pass

--- a/terracotta/exceptions.py
+++ b/terracotta/exceptions.py
@@ -27,5 +27,6 @@ class InvalidDatabaseError(Exception):
 class PerformanceWarning(UserWarning):
     pass
 
+
 class DeprecationWarning(UserWarning):
     pass

--- a/tests/drivers/test_drivers.py
+++ b/tests/drivers/test_drivers.py
@@ -277,7 +277,7 @@ def test_use_credentials_from_settings(driver_path, provider, monkeypatch):
             assert meta_store_class._parse_path('').username == 'foo'
             assert meta_store_class._parse_path('').password == 'bar'
 
-            driver_path_without_credentials = driver_path[driver_path.find('@')+1:]
+            driver_path_without_credentials = driver_path[driver_path.find('@') + 1:]
             db = drivers.get_driver(driver_path_without_credentials, provider)
             assert db.meta_store.url.username == 'foo'
             assert db.meta_store.url.password == 'bar'

--- a/tests/drivers/test_drivers.py
+++ b/tests/drivers/test_drivers.py
@@ -261,3 +261,23 @@ def test_invalid_key_types(driver_path, provider):
     with pytest.raises(exceptions.InvalidKeyError) as exc:
         db.get_datasets({'not-a-key': 'val'})
     assert 'unrecognized keys' in str(exc)
+
+
+@pytest.mark.parametrize('provider', TESTABLE_DRIVERS)
+def test_use_credentials_from_settings(driver_path, provider, monkeypatch):
+    with monkeypatch.context() as m:
+        m.setenv('TC_SQL_USER', 'foo')
+        m.setenv('TC_SQL_PASSWORD', 'bar')
+
+        from terracotta import drivers, update_settings
+        update_settings()
+
+        if 'sqlite' not in provider:
+            meta_store_class = drivers.load_driver(provider)
+            assert meta_store_class._parse_path('').username == 'foo'
+            assert meta_store_class._parse_path('').password == 'bar'
+
+            driver_path_without_credentials = driver_path[driver_path.find('@')+1:]
+            db = drivers.get_driver(driver_path_without_credentials, provider)
+            assert db.meta_store.url.username == 'foo'
+            assert db.meta_store.url.password == 'bar'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -86,7 +86,7 @@ def test_deprecation_behaviour(monkeypatch):
 
             with pytest.warns(exceptions.DeprecationWarning) as warning:
                 update_settings()
-            assert f'TC_{deprecated_field} is being deprecated' in str(warning[0])
+            assert f'TC_{deprecated_field} is deprecated' in str(warning[0])
 
             assert getattr(get_settings(), deprecated_field) == 'foo'
             assert getattr(get_settings(), new_field) == 'foo'
@@ -95,7 +95,7 @@ def test_deprecation_behaviour(monkeypatch):
 
             with pytest.warns(exceptions.DeprecationWarning) as warning:
                 update_settings()
-            assert f'TC_{deprecated_field} is being deprecated' in str(warning[0])
+            assert f'TC_{deprecated_field} is deprecated' in str(warning[0])
 
             assert getattr(get_settings(), deprecated_field) == 'foo'
             assert getattr(get_settings(), new_field) == 'bar'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -95,7 +95,7 @@ def test_deprecation_behaviour(monkeypatch):
 
             with pytest.warns(exceptions.DeprecationWarning) as warning:
                 update_settings()
-            assert f'and its replacement TC_{new_field} is set' in str(warning[0])
+            assert f'TC_{deprecated_field} is being deprecated' in str(warning[0])
 
             assert getattr(get_settings(), deprecated_field) == 'foo'
             assert getattr(get_settings(), new_field) == 'bar'


### PR DESCRIPTION
The `SQLAlchemy` broke setting `MYSQL_USER` and `MYSQL_PASSWORD` settings. This PR fixes that.

It also renames the fields from `MYSQL_*` to the more generic `SQL_*`, in anticipation of the coming `PostgreSQL` driver (and potential future others). This is currently just a plain rename, thus breaking compatibility with deployments using the previous fields. We need to decide whether that is okay, or whether there should be some deprecation warning system first.

Ideally, we also ought to make some tests for this. I have apparently previously broken this, without noticing. That shouldn't be possible in the future. Feel free to just add such tests -- it may take a while before I'm back to do it.