### PR TITLE
Test using postgresql meta store as well

### DIFF
--- a/tests/drivers/test_raster_drivers.py
+++ b/tests/drivers/test_raster_drivers.py
@@ -5,7 +5,7 @@ import time
 
 import numpy as np
 
-DRIVERS = ['sqlite', 'mysql', 'postgresql']
+DRIVERS = ['sqlite']
 METADATA_KEYS = ('bounds', 'range', 'mean', 'stdev', 'percentiles', 'metadata')
 
 

--- a/tests/drivers/test_raster_drivers.py
+++ b/tests/drivers/test_raster_drivers.py
@@ -5,7 +5,7 @@ import time
 
 import numpy as np
 
-DRIVERS = ['sqlite', 'mysql']
+DRIVERS = ['sqlite', 'mysql', 'postgresql']
 METADATA_KEYS = ('bounds', 'range', 'mean', 'stdev', 'percentiles', 'metadata')
 
 


### PR DESCRIPTION
Include the `postgresql` driver/meta store for testing in `test_raster_drivers.py`. I assume this shall be done?

We arguably ought to restructure the tests to match our new raster/meta store structure, but I'll leave that for the future 😄 