### PR TITLE
Issue262

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
         'shapely',
         'rasterio>=1.0',
         'shapely',
-        'sqlalchemy',
+        'sqlalchemy>=1.4.1',
         'toml',
         'tqdm'
     ],
@@ -91,7 +91,7 @@ setup(
             'moto',
             'aws-xray-sdk',
             'pymysql>=1.0.0',
-            'psycopg2'
+            'psycopg2-binary'
         ],
         'docs': [
             'sphinx',

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ setup(
             'moto',
             'aws-xray-sdk',
             'pymysql>=1.0.0',
-            'psycopg2-binary'
+            'psycopg2'
         ],
         'docs': [
             'sphinx',


### PR DESCRIPTION
This fixes #262.

We use functionality from `SQLAlchemy 1.4`, and apparently `ColumnCollection.values()` was missing in `1.4.0`, but added back in `1.4.1`.