### PR TITLE
Set default db connection timeout to 100 seconds

### DIFF
--- a/terracotta/config.py
+++ b/terracotta/config.py
@@ -50,7 +50,7 @@ class TerracottaSettings(NamedTuple):
     PNG_COMPRESS_LEVEL: int = 1
 
     #: Timeout in seconds for database connections
-    DB_CONNECTION_TIMEOUT: int = 10
+    DB_CONNECTION_TIMEOUT: int = 100
 
     #: Path where cached remote SQLite databases are stored (when using sqlite-remote provider)
     REMOTE_DB_CACHE_DIR: str = os.path.join(tempfile.gettempdir(), 'terracotta')


### PR DESCRIPTION
I just noticed that in the last version it seems that from the time I run `tc.get_driver()` I have 10 seconds until the connection to the DB dies. I suggest that the default value should be much higher that 10 seconds. Set it to 100 for now.