### PR TITLE
Issue 266

### DIFF
--- a/terracotta/drivers/relational_meta_store.py
+++ b/terracotta/drivers/relational_meta_store.py
@@ -89,6 +89,7 @@ class RelationalMetaStore(MetaStore, ABC):
             echo=False,
             future=True,
             connect_args={self.SQL_TIMEOUT_KEY: db_connection_timeout},
+            # automatically re-spawn stale connections, see terracotta#266
             pool_pre_ping=True
         )
         self.sqla_metadata = sqla.MetaData()

--- a/terracotta/drivers/relational_meta_store.py
+++ b/terracotta/drivers/relational_meta_store.py
@@ -88,7 +88,8 @@ class RelationalMetaStore(MetaStore, ABC):
             self.url,
             echo=False,
             future=True,
-            connect_args={self.SQL_TIMEOUT_KEY: db_connection_timeout}
+            connect_args={self.SQL_TIMEOUT_KEY: db_connection_timeout},
+            pool_pre_ping=True
         )
         self.sqla_metadata = sqla.MetaData()
 


### PR DESCRIPTION
This fixes #266.
Set `pool_pre_ping` to `True` when creating the sqlalchemy engine as discussed in #266 