### PR TITLE
Wmts

### DIFF
--- a/terracotta/handlers/wmts.py
+++ b/terracotta/handlers/wmts.py
@@ -1,0 +1,57 @@
+"""handlers/wmts.py
+
+Handle /wmts API endpoint.
+"""
+
+from typing import Any, Mapping, List, Sequence, Union  # noqa: F401
+from collections import OrderedDict
+
+from terracotta import get_settings, get_driver
+from terracotta.profile import trace
+
+import xml.etree.ElementTree as ET
+import importlib.resources
+import terracotta.handlers as package
+
+
+@trace('wmts_handler')
+def wmts(url_root: str) -> Any:
+    """  """
+    settings = get_settings()
+    driver = get_driver(settings.DRIVER_PATH, provider=settings.DRIVER_PROVIDER)
+
+    datasets = driver.get_datasets()
+    dataset = list(datasets.keys())[0]
+
+    # dataset = ('2020', '1')
+
+    for _, (prefix, uri) in ET.iterparse(importlib.resources.open_text(package, 'wmts.xml'), events=['start-ns']):
+        ET.register_namespace(prefix, uri)
+
+    get_capabilities_xml_tree = ET.parse(importlib.resources.open_text(package, 'wmts.xml'))
+    for el in get_capabilities_xml_tree.getroot().findall('.//{http://www.opengis.net/ows/1.1}Get'):
+        el.set('xlink:href', f'{url_root}wmts')
+    get_capabilities_xml_tree.find('.//{http://www.opengis.net/wmts/1.0}ServiceMetadataURL').set('xlink:href', f'{url_root}wmts')
+    contents_element = get_capabilities_xml_tree.find('.//{http://www.opengis.net/wmts/1.0}Contents')
+
+    layer = ET.Element('Layer')
+    ET.SubElement(layer, 'ows:Title').text = 'Title'
+    ET.SubElement(layer, 'ows:Identifier').text = 'Layer name'
+    ET.SubElement(layer, 'ows:Abstract').text = 'Description'
+    bbox = ET.SubElement(layer, 'ows:WGS84BoundingBox', crs='urn:ogc:def:crs:OGC:2:84')
+    ET.SubElement(bbox, 'ows:LowerCorner').text = ' '.join(map(str, driver.get_metadata(dataset)['bounds'][:2]))
+    ET.SubElement(bbox, 'ows:UpperCorner').text = ' '.join(map(str, driver.get_metadata(dataset)['bounds'][2:]))
+    style = ET.SubElement(layer, 'Style', isDefault='true')
+    ET.SubElement(style, 'ows:Identifier').text = 'default'
+    ET.SubElement(layer, 'Format').text = 'image/png'
+    tile_matrix_set_link = ET.SubElement(layer, 'TileMatrixSetLink')
+    ET.SubElement(tile_matrix_set_link, 'TileMatrixSet').text = 'WorldWebMercatorQuad'
+    ET.SubElement(
+        layer, 'ResourceURL',
+        format='image/png',
+        resourceType='tile',
+        template=f'{url_root}singleband/{"/".join(dataset)}/' + '{TileMatrix}/{TileCol}/{TileRow}.png'
+    )
+    contents_element.append(layer)
+
+    return ET.tostring(get_capabilities_xml_tree.getroot(), encoding='unicode')

--- a/terracotta/handlers/wmts.py
+++ b/terracotta/handlers/wmts.py
@@ -3,27 +3,33 @@
 Handle /wmts API endpoint.
 """
 
-from typing import Any, Mapping, List, Sequence, Union  # noqa: F401
-from collections import OrderedDict
-
-from terracotta import get_settings, get_driver
-from terracotta.profile import trace
-
-import xml.etree.ElementTree as ET
 import importlib.resources
+from typing import Tuple
+import xml.etree.ElementTree as ET
+
 import terracotta.handlers as package
+from terracotta import get_driver, get_settings
+from terracotta.profile import trace
 
 
 @trace('wmts_handler')
-def wmts(url_root: str) -> Any:
+def wmts(url_root: str, dimension: str = None) -> str:
     """  """
     settings = get_settings()
     driver = get_driver(settings.DRIVER_PATH, provider=settings.DRIVER_PROVIDER)
 
-    datasets = driver.get_datasets()
-    dataset = list(datasets.keys())[0]
+    assert dimension is None or dimension in driver.key_names
+    key_indices = {key: i for i, key in enumerate(driver.key_names)}
+    dimension_index = key_indices[dimension] if dimension is not None else None
 
-    # dataset = ('2020', '1')
+    def dataset_without_dimension(dataset: Tuple[str,...]) -> Tuple[str, ...]:
+        if dimension is None:
+            return dataset
+        else:
+            return dataset[:dimension_index] + dataset[dimension_index + 1:]
+
+    datasets = driver.get_datasets()
+    summarised_datasets = set(map(dataset_without_dimension, datasets))
 
     for _, (prefix, uri) in ET.iterparse(importlib.resources.open_text(package, 'wmts.xml'), events=['start-ns']):
         ET.register_namespace(prefix, uri)
@@ -34,24 +40,36 @@ def wmts(url_root: str) -> Any:
     get_capabilities_xml_tree.find('.//{http://www.opengis.net/wmts/1.0}ServiceMetadataURL').set('xlink:href', f'{url_root}wmts')
     contents_element = get_capabilities_xml_tree.find('.//{http://www.opengis.net/wmts/1.0}Contents')
 
-    layer = ET.Element('Layer')
-    ET.SubElement(layer, 'ows:Title').text = 'Title'
-    ET.SubElement(layer, 'ows:Identifier').text = 'Layer name'
-    ET.SubElement(layer, 'ows:Abstract').text = 'Description'
-    bbox = ET.SubElement(layer, 'ows:WGS84BoundingBox', crs='urn:ogc:def:crs:OGC:2:84')
-    ET.SubElement(bbox, 'ows:LowerCorner').text = ' '.join(map(str, driver.get_metadata(dataset)['bounds'][:2]))
-    ET.SubElement(bbox, 'ows:UpperCorner').text = ' '.join(map(str, driver.get_metadata(dataset)['bounds'][2:]))
-    style = ET.SubElement(layer, 'Style', isDefault='true')
-    ET.SubElement(style, 'ows:Identifier').text = 'default'
-    ET.SubElement(layer, 'Format').text = 'image/png'
-    tile_matrix_set_link = ET.SubElement(layer, 'TileMatrixSetLink')
-    ET.SubElement(tile_matrix_set_link, 'TileMatrixSet').text = 'WorldWebMercatorQuad'
-    ET.SubElement(
-        layer, 'ResourceURL',
-        format='image/png',
-        resourceType='tile',
-        template=f'{url_root}singleband/{"/".join(dataset)}/' + '{TileMatrix}/{TileCol}/{TileRow}.png'
-    )
-    contents_element.append(layer)
+    for dataset in summarised_datasets:
+        dimension_datasets = list(filter(lambda ds: dataset_without_dimension(ds) == dataset, datasets))
+
+        layer = ET.Element('Layer')
+        ET.SubElement(layer, 'ows:Title').text = 'Title'
+        ET.SubElement(layer, 'ows:Identifier').text = 'Layer name'
+        ET.SubElement(layer, 'ows:Abstract').text = 'Description'
+        bbox = ET.SubElement(layer, 'ows:WGS84BoundingBox', crs='urn:ogc:def:crs:OGC:2:84')
+        bounds = driver.get_metadata(dimension_datasets[0])['bounds']
+        ET.SubElement(bbox, 'ows:LowerCorner').text = ' '.join(map(str, bounds[:2]))
+        ET.SubElement(bbox, 'ows:UpperCorner').text = ' '.join(map(str, bounds[2:]))
+        style = ET.SubElement(layer, 'Style', isDefault='true')
+        ET.SubElement(style, 'ows:Identifier').text = 'default'
+        ET.SubElement(layer, 'Format').text = 'image/png'
+        if dimension:
+            dimension_values = [ds[dimension_index] for ds in dimension_datasets]
+            dimension_element = ET.SubElement(layer, 'Dimension')
+            ET.SubElement(dimension_element, 'ows:Identifier').text = dimension
+            ET.SubElement(dimension_element, 'Default').text = dimension_values[0]
+            for dimension_value in dimension_values:
+                ET.SubElement(dimension_element, 'Value').text = dimension_value
+        tile_matrix_set_link = ET.SubElement(layer, 'TileMatrixSetLink')
+        ET.SubElement(tile_matrix_set_link, 'TileMatrixSet').text = 'WorldWebMercatorQuad'
+        dataset_keys = '/'.join(dataset if dimension is None else dataset[:dimension_index] + (f'{{{dimension}}}',) + dataset[dimension_index:])
+        ET.SubElement(
+            layer, 'ResourceURL',
+            format='image/png',
+            resourceType='tile',
+            template=f'{url_root}singleband/{dataset_keys}/{{TileMatrix}}/{{TileCol}}/{{TileRow}}.png'
+        )
+        contents_element.append(layer)
 
     return ET.tostring(get_capabilities_xml_tree.getroot(), encoding='unicode')

--- a/terracotta/handlers/wmts.xml
+++ b/terracotta/handlers/wmts.xml
@@ -1,0 +1,220 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Capabilities xmlns="http://www.opengis.net/wmts/1.0" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:gml="http://www.opengis.net/gml" xsi:schemaLocation="http://www.opengis.net/wmts/1.0 http://schemas.opengis.net/wmts/1.0/wmtsGetCapabilities_response.xsd" version="1.0.0">
+    <ows:ServiceIdentification>
+        <ows:Title>"Title"</ows:Title>
+        <ows:ServiceType>OGC WMTS</ows:ServiceType>
+        <ows:ServiceTypeVersion>1.0.0</ows:ServiceTypeVersion>
+    </ows:ServiceIdentification>
+    <ows:OperationsMetadata>
+        <ows:Operation name="GetCapabilities">
+            <ows:DCP>
+                <ows:HTTP>
+                    <ows:Get>
+                        <ows:Constraint name="GetEncoding">
+                            <ows:AllowedValues>
+                                <ows:Value>RESTful</ows:Value>
+                            </ows:AllowedValues>
+                        </ows:Constraint>
+                    </ows:Get>
+                </ows:HTTP>
+            </ows:DCP>
+        </ows:Operation>
+        <ows:Operation name="GetTile">
+            <ows:DCP>
+                <ows:HTTP>
+                    <ows:Get>
+                        <ows:Constraint name="GetEncoding">
+                            <ows:AllowedValues>
+                                <ows:Value>RESTful</ows:Value>
+                            </ows:AllowedValues>
+                        </ows:Constraint>
+                    </ows:Get>
+                </ows:HTTP>
+            </ows:DCP>
+        </ows:Operation>
+    </ows:OperationsMetadata>
+    <Contents>
+        <TileMatrixSet>
+            <ows:Title>Google Maps Compatible for the World</ows:Title>
+            <ows:Identifier>WorldWebMercatorQuad</ows:Identifier>
+            <ows:BoundingBox crs="urn:ogc:def:crs:EPSG::3857">
+                <ows:LowerCorner>-20037508.3427892 -20037508.3427892</ows:LowerCorner>
+                <ows:UpperCorner>20037508.3427892 20037508.3427892</ows:UpperCorner>
+            </ows:BoundingBox>
+            <ows:SupportedCRS>urn:ogc:def:crs:EPSG::3857</ows:SupportedCRS>
+            <WellKnownScaleSet>urn:ogc:def:wkss:OGC:1.0:GoogleMapsCompatible</WellKnownScaleSet>
+            <TileMatrix>
+                <ows:Identifier>0</ows:Identifier>
+                <ScaleDenominator>559082264.0287178</ScaleDenominator>
+                <TopLeftCorner>-20037508.3427892 20037508.3427892</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>1</MatrixWidth>
+                <MatrixHeight>1</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>1</ows:Identifier>
+                <ScaleDenominator>279541132.0143589</ScaleDenominator>
+                <TopLeftCorner>-20037508.3427892 20037508.3427892</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>2</MatrixWidth>
+                <MatrixHeight>2</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>2</ows:Identifier>
+                <ScaleDenominator>139770566.0071794</ScaleDenominator>
+                <TopLeftCorner>-20037508.3427892 20037508.3427892</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>4</MatrixWidth>
+                <MatrixHeight>4</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>3</ows:Identifier>
+                <ScaleDenominator>69885283.00358972</ScaleDenominator>
+                <TopLeftCorner>-20037508.3427892 20037508.3427892</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>8</MatrixWidth>
+                <MatrixHeight>8</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>4</ows:Identifier>
+                <ScaleDenominator>34942641.50179486</ScaleDenominator>
+                <TopLeftCorner>-20037508.3427892 20037508.3427892</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>16</MatrixWidth>
+                <MatrixHeight>16</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>5</ows:Identifier>
+                <ScaleDenominator>17471320.75089743</ScaleDenominator>
+                <TopLeftCorner>-20037508.3427892 20037508.3427892</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>32</MatrixWidth>
+                <MatrixHeight>32</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>6</ows:Identifier>
+                <ScaleDenominator>8735660.375448715</ScaleDenominator>
+                <TopLeftCorner>-20037508.3427892 20037508.3427892</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>64</MatrixWidth>
+                <MatrixHeight>64</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>7</ows:Identifier>
+                <ScaleDenominator>4367830.187724357</ScaleDenominator>
+                <TopLeftCorner>-20037508.3427892 20037508.3427892</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>128</MatrixWidth>
+                <MatrixHeight>128</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>8</ows:Identifier>
+                <ScaleDenominator>2183915.093862179</ScaleDenominator>
+                <TopLeftCorner>-20037508.3427892 20037508.3427892</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>256</MatrixWidth>
+                <MatrixHeight>256</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>9</ows:Identifier>
+                <ScaleDenominator>1091957.546931089</ScaleDenominator>
+                <TopLeftCorner>-20037508.3427892 20037508.3427892</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>512</MatrixWidth>
+                <MatrixHeight>512</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>10</ows:Identifier>
+                <ScaleDenominator>545978.7734655447</ScaleDenominator>
+                <TopLeftCorner>-20037508.3427892 20037508.3427892</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>1024</MatrixWidth>
+                <MatrixHeight>1024</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>11</ows:Identifier>
+                <ScaleDenominator>272989.3867327723</ScaleDenominator>
+                <TopLeftCorner>-20037508.3427892 20037508.3427892</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>2048</MatrixWidth>
+                <MatrixHeight>2048</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>12</ows:Identifier>
+                <ScaleDenominator>136494.6933663862</ScaleDenominator>
+                <TopLeftCorner>-20037508.3427892 20037508.3427892</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>4096</MatrixWidth>
+                <MatrixHeight>4096</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>13</ows:Identifier>
+                <ScaleDenominator>68247.34668319309</ScaleDenominator>
+                <TopLeftCorner>-20037508.3427892 20037508.3427892</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>8192</MatrixWidth>
+                <MatrixHeight>8192</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>14</ows:Identifier>
+                <ScaleDenominator>34123.67334159654</ScaleDenominator>
+                <TopLeftCorner>-20037508.3427892 20037508.3427892</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>16384</MatrixWidth>
+                <MatrixHeight>16384</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>15</ows:Identifier>
+                <ScaleDenominator>17061.83667079827</ScaleDenominator>
+                <TopLeftCorner>-20037508.3427892 20037508.3427892</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>32768</MatrixWidth>
+                <MatrixHeight>32768</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>16</ows:Identifier>
+                <ScaleDenominator>8530.918335399136</ScaleDenominator>
+                <TopLeftCorner>-20037508.3427892 20037508.3427892</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>65536</MatrixWidth>
+                <MatrixHeight>65536</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>17</ows:Identifier>
+                <ScaleDenominator>4265.459167699568</ScaleDenominator>
+                <TopLeftCorner>-20037508.3427892 20037508.3427892</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>131072</MatrixWidth>
+                <MatrixHeight>131072</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>18</ows:Identifier>
+                <ScaleDenominator>2132.729583849784</ScaleDenominator>
+                <TopLeftCorner>-20037508.3427892 20037508.3427892</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>262114</MatrixWidth>
+                <MatrixHeight>262114</MatrixHeight>
+            </TileMatrix>
+        </TileMatrixSet>
+    </Contents>
+    <ServiceMetadataURL/>
+</Capabilities>

--- a/terracotta/server/flask_api.py
+++ b/terracotta/server/flask_api.py
@@ -97,6 +97,7 @@ def create_app(debug: bool = False, profile: bool = False) -> Flask:
     import terracotta.server.rgb
     import terracotta.server.singleband
     import terracotta.server.compute
+    import terracotta.server.wmts
 
     new_app = Flask('terracotta.server')
     new_app.debug = debug
@@ -128,6 +129,7 @@ def create_app(debug: bool = False, profile: bool = False) -> Flask:
         SPEC.path(view=terracotta.server.singleband.get_singleband_preview)
         SPEC.path(view=terracotta.server.compute.get_compute)
         SPEC.path(view=terracotta.server.compute.get_compute_preview)
+        SPEC.path(view=terracotta.server.wmts.get_wmts_capabilities)
 
     import terracotta.server.spec
     new_app.register_blueprint(SPEC_API, url_prefix='')

--- a/terracotta/server/wmts.py
+++ b/terracotta/server/wmts.py
@@ -1,0 +1,15 @@
+"""server/wmts.py
+
+Flask route to handle /wmts calls.
+"""
+
+from flask import jsonify, Response, request
+from marshmallow import Schema, fields
+
+from terracotta.server.flask_api import METADATA_API
+
+
+@METADATA_API.route('/wmts', methods=['GET'])
+def get_wmts_capabilities() -> Response:
+    from terracotta.handlers.wmts import wmts
+    return Response(wmts(request.url_root), mimetype='text/xml')

--- a/terracotta/server/wmts.py
+++ b/terracotta/server/wmts.py
@@ -4,12 +4,23 @@ Flask route to handle /wmts calls.
 """
 
 from flask import jsonify, Response, request
-from marshmallow import Schema, fields
+from marshmallow import Schema, fields, EXCLUDE
 
 from terracotta.server.flask_api import METADATA_API
+
+
+class DimensionOptionSchema(Schema):
+    class Meta:
+        unknown = EXCLUDE
+
+    dimension = fields.String(required=False, default=None, description='Key to make dimension along')
 
 
 @METADATA_API.route('/wmts', methods=['GET'])
 def get_wmts_capabilities() -> Response:
     from terracotta.handlers.wmts import wmts
-    return Response(wmts(request.url_root), mimetype='text/xml')
+    option_schema = DimensionOptionSchema()
+    options = option_schema.load(request.args)
+
+    capabilities = wmts(request.url_root, options.get('dimension'))
+    return Response(capabilities, mimetype='text/xml')


### PR DESCRIPTION
Experimental support for WMTS, including the `Dimension` tag. This is at the moment pretty much a working proof-of-concept, initially just to test the feasibility. A lot of polishing is required before it may become ready to merge.

But first, is this a feature we want to add? It is suprisingly simple, and doesn't add much complexity, as it primarily relies on existing functionality. It essentially just provides an endpoint for fetching `GetCapabilities` -- the rest is handled as usual.

As far as I can tell the implementation adheres to the [WMTS standard](https://portal.ogc.org/files/?artifact_id=35326). I've cross-checked with [Titiler](https://github.com/developmentseed/titiler) as a reference point, and the processes seem comparable (apart from their implementation being much more generalised). The implementation is tested in QGIS on small test rasters.

Remaining tasks and questions (if we want to add it):
1. Support usage of all the normal endpoints for rasters; `/rgb`, `/compute`(?), as well as `/singleband`, along with all their options. This is currently hardcoded to `/singleband` without any options.
2. Dynamically add zoom levels instead of hardcoding them in the `wmts.xml` template file? If doing so, data is available here http://schemas.opengis.net/tms/1.0/json/examples/.
3. Are there any restrictions on zoom levels? I've used [Titiler](https://github.com/developmentseed/titiler) for reference, and see that they [deduce zoom level restrictions](https://github.com/developmentseed/titiler/blob/cb2a5b1432b651a95e79de13203151e738c57775/src/titiler/core/titiler/core/factory.py#L687-L688) from data, somehow. Does Terracotta have such limits?
4. Is it correctly understood that `WorldWebMercatorQuad` is the correct reference system?
5. I've used `xml.etree.ElementTree` to build the capabilities XML file. It seems like the proper way for me, but I'm not satisfied with the code. I think it is too convoluted, and frankly hard to read. I'm actually leaning towards inserting elements as strings in the template instead. Thoughts on this?
6. Where shall static template/data files be stored? Regarding the `wmts.xml` and possibly `WebMercatorQuad.json` file(s).
7. Currently the `dimension` option blindly trusts the user that the supplied key makes sense as a dimension (ie that the raster files have the same bounds). Shall we verify this?
8. Documentation.
9. Testing. No efforts have been made here yet.
