### PR TITLE
Add a first example ingestion script to the docs

### DIFF
--- a/docs/_static/example-first-ingestion-script.py
+++ b/docs/_static/example-first-ingestion-script.py
@@ -1,0 +1,70 @@
+import os
+from typing import Dict, List
+
+import terracotta
+
+# Define the location of the SQLite database
+# (this will be created if it doesn't already exist)
+DB_NAME = "./terracotta.sqlite"
+
+# Define the list of keys that will be used to identify datasets.
+# (these must match the keys of the "key_values" dicts defined in
+# RASTER_FILES)
+KEYS = ["type", "rp", "rcp", "epoch", "gcm"]
+
+# Define a list of raster files to import
+# (this is a list of dictionaries, each with a file path and the
+# values for each key - make sure the order matches the order of
+# KEYS defined above)
+#
+# This part of the script could be replaced with something that
+# makes sense for your data - it could use a glob expression to
+# find all TIFFs and a regular expression pattern to extract the
+# key values, or it could read from a CSV, or use some other
+# reference or metadata generating process.
+RASTER_FILES = [
+    {
+        "key_values": {
+            "type": "river",
+            "rp": 250,
+            "rcp": 4.5,
+            "epoch": 2030,
+            "gcm": "NorESM1-M",
+        },
+        "path": "./data/river__rp_250__rcp_4x5__epoch_2030__gcm_NorESM1-M.tif",
+    },
+    {
+        "key_values": {
+            "type": "river",
+            "rp": 500,
+            "rcp": 8.5,
+            "epoch": 2080,
+            "gcm": "NorESM1-M",
+        },
+        "path": "./data/river__rp_500__rcp_8x5__epoch_2080__gcm_NorESM1-M.tif",
+    },
+]
+
+
+def load(db_name: str, keys: List[str], raster_files: List[Dict]):
+    # get a TerracottaDriver that we can use to interact with
+    # the database
+    driver = terracotta.get_driver(db_name)
+
+    # create the database file if it doesn't exist already
+    if not os.path.isfile(db_name):
+        driver.create(keys)
+
+    # check that the database has the same keys that we want
+    # to load
+    assert list(driver.key_names) == keys, (driver.key_names, keys)
+
+    # connect to the database
+    with driver.connect():
+        # insert metadata for each raster into the database
+        for raster in raster_files:
+            driver.insert(raster["key_values"], raster["path"])
+
+
+if __name__ == "__main__":
+    load(DB_NAME, KEYS, RASTER_FILES)

--- a/docs/get-started.rst
+++ b/docs/get-started.rst
@@ -140,8 +140,32 @@ different times:
 3. On demand when a dataset is requested for the first time (this is
    what we want to avoid through ingestion).
 
-An example ingestion script using the Python API
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A first ingestion script using the Python API
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The following script first defines three variables that we need to work with a
+terracotta database:
+
+- the database filename
+- the metadata keys that we will use
+- the metadata key-values and paths to raster files that we want to insert
+
+Then it uses the Python API to connect to the database and insert the metadata.
+
+.. literalinclude:: _static/example-first-ingestion-script.py
+   :language: python
+   :caption: example-first-ingestion-script.py
+
+:download:`Download the script <_static/example-first-ingestion-script.py>`
+
+You could start adapting this script by changing the variable definitions to
+match the data you want to ingest. A next step could be to read the metadata
+from a CSV or parse it from the filenames of the raster data.
+
+
+A more advanced ingestion script using the Python API
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The following script populates a database with raster files located in a
 local directory. It extracts the appropriate keys from the file name,
@@ -156,7 +180,7 @@ database into an S3 bucket.
 
 .. note::
 
-   The above script is just a simple example to show you some
+   The above scripts are just examples to show you some
    capabilities of the Terracotta Python API. More sophisticated solutions
    could e.g. attach additional metadata to database entries, process
    many rasters in parallel, or accept parameters from the command line.


### PR DESCRIPTION
This adds the example discussed in #271 to the getting started docs, aiming to provide a first example script that uses as little as possible of the terracotta API and not much core Python or other libraries either! Hopefully a good starting point for more novice users.