### PR TITLE
feat: add endpoint for querying multiple metadata

### DIFF
--- a/terracotta/config.py
+++ b/terracotta/config.py
@@ -161,6 +161,8 @@ class SettingSchema(Schema):
 
     USE_MULTIPROCESSING = fields.Boolean()
 
+    MAX_POST_METADATA_KEYS = fields.Integer(validate=validate.Range(min=1))
+
     @pre_load
     def decode_lists(self, data: Dict[str, Any], **kwargs: Any) -> Dict[str, Any]:
         for var in (

--- a/terracotta/config.py
+++ b/terracotta/config.py
@@ -92,6 +92,9 @@ class TerracottaSettings(NamedTuple):
     #: Use a process pool for band retrieval in parallel
     USE_MULTIPROCESSING: bool = True
 
+    #: Maximum number of metadata keys per POST /metadata request
+    MAX_POST_METADATA_KEYS: int = 100
+
 
 AVAILABLE_SETTINGS: Tuple[str, ...] = TerracottaSettings._fields
 

--- a/terracotta/handlers/metadata.py
+++ b/terracotta/handlers/metadata.py
@@ -46,9 +46,10 @@ def multiple_metadata(
     key_names = driver.key_names
 
     out = []
-    for dataset in datasets:
-        metadata = filter_metadata(driver.get_metadata(dataset), columns)
-        metadata["keys"] = OrderedDict(zip(key_names, dataset))
-        out.append(metadata)
+    with driver.connect():
+        for dataset in datasets:
+            metadata = filter_metadata(driver.get_metadata(dataset), columns)
+            metadata["keys"] = OrderedDict(zip(key_names, dataset))
+            out.append(metadata)
 
     return out

--- a/terracotta/handlers/metadata.py
+++ b/terracotta/handlers/metadata.py
@@ -10,9 +10,13 @@ from terracotta import get_settings, get_driver
 from terracotta.profile import trace
 
 
-def filter_metadata(metadata: Dict[str, Any], columns: Optional[List[str]]) -> Dict[str, Any]:
+def filter_metadata(
+    metadata: Dict[str, Any], columns: Optional[List[str]]
+) -> Dict[str, Any]:
     """Filter metadata by columns, if given"""
-    assert columns is None or len(columns) > 0, "columns must either be a non-empty list or None"
+    assert (
+        columns is None or len(columns) > 0
+    ), "columns must either be a non-empty list or None"
 
     if columns:
         metadata = {c: metadata[c] for c in columns}
@@ -21,7 +25,9 @@ def filter_metadata(metadata: Dict[str, Any], columns: Optional[List[str]]) -> D
 
 
 @trace("metadata_handler")
-def metadata(columns: Optional[List[str]], keys: Union[Sequence[str], Mapping[str, str]]) -> Dict[str, Any]:
+def metadata(
+    columns: Optional[List[str]], keys: Union[Sequence[str], Mapping[str, str]]
+) -> Dict[str, Any]:
     """Returns all metadata for a single dataset"""
     settings = get_settings()
     driver = get_driver(settings.DRIVER_PATH, provider=settings.DRIVER_PROVIDER)
@@ -31,7 +37,9 @@ def metadata(columns: Optional[List[str]], keys: Union[Sequence[str], Mapping[st
 
 
 @trace("multiple_metadata_handler")
-def multiple_metadata(columns: Optional[List[str]], datasets: List[List[str]]) -> List[Dict[str, Any]]:
+def multiple_metadata(
+    columns: Optional[List[str]], datasets: List[List[str]]
+) -> List[Dict[str, Any]]:
     """Returns all metadata for multiple datasets"""
     settings = get_settings()
     driver = get_driver(settings.DRIVER_PATH, provider=settings.DRIVER_PROVIDER)

--- a/terracotta/handlers/metadata.py
+++ b/terracotta/handlers/metadata.py
@@ -47,7 +47,7 @@ def multiple_metadata(
 
     out = []
     with driver.connect():
-        for dataset in datasets:
+        for dataset in datasets[:settings.MAX_POST_METADATA_KEYS]:
             metadata = filter_metadata(driver.get_metadata(dataset), columns)
             metadata["keys"] = OrderedDict(zip(key_names, dataset))
             out.append(metadata)

--- a/terracotta/handlers/metadata.py
+++ b/terracotta/handlers/metadata.py
@@ -47,7 +47,7 @@ def multiple_metadata(
 
     out = []
     with driver.connect():
-        for dataset in datasets[:settings.MAX_POST_METADATA_KEYS]:
+        for dataset in datasets[: settings.MAX_POST_METADATA_KEYS]:
             metadata = filter_metadata(driver.get_metadata(dataset), columns)
             metadata["keys"] = OrderedDict(zip(key_names, dataset))
             out.append(metadata)

--- a/terracotta/handlers/metadata.py
+++ b/terracotta/handlers/metadata.py
@@ -7,6 +7,7 @@ from typing import Mapping, Sequence, Dict, Any, Union, List, Optional
 from collections import OrderedDict
 
 from terracotta import get_settings, get_driver
+from terracotta.exceptions import InvalidArgumentsError
 from terracotta.profile import trace
 
 
@@ -45,9 +46,15 @@ def multiple_metadata(
     driver = get_driver(settings.DRIVER_PATH, provider=settings.DRIVER_PROVIDER)
     key_names = driver.key_names
 
+    if len(datasets) > settings.MAX_POST_METADATA_KEYS:
+        raise InvalidArgumentsError(
+            f"Maximum number of keys exceeded ({settings.MAX_POST_METADATA_KEYS}). "
+            f"This limit can be configured in the server settings."
+        )
+
     out = []
     with driver.connect():
-        for dataset in datasets[: settings.MAX_POST_METADATA_KEYS]:
+        for dataset in datasets:
             metadata = filter_metadata(driver.get_metadata(dataset), columns)
             metadata["keys"] = OrderedDict(zip(key_names, dataset))
             out.append(metadata)

--- a/terracotta/handlers/metadata.py
+++ b/terracotta/handlers/metadata.py
@@ -3,18 +3,44 @@
 Handle /metadata API endpoint.
 """
 
-from typing import Mapping, Sequence, Dict, Any, Union
+from typing import Mapping, Sequence, Dict, Any, Union, List, Optional
 from collections import OrderedDict
 
 from terracotta import get_settings, get_driver
 from terracotta.profile import trace
 
 
+def filter_metadata(metadata: Dict[str, Any], columns: Optional[List[str]]) -> Dict[str, Any]:
+    """Filter metadata by columns, if given"""
+    assert columns is None or len(columns) > 0, "columns must either be a non-empty list or None"
+
+    if columns:
+        metadata = {c: metadata[c] for c in columns}
+
+    return metadata
+
+
 @trace("metadata_handler")
-def metadata(keys: Union[Sequence[str], Mapping[str, str]]) -> Dict[str, Any]:
+def metadata(columns: Optional[List[str]], keys: Union[Sequence[str], Mapping[str, str]]) -> Dict[str, Any]:
     """Returns all metadata for a single dataset"""
     settings = get_settings()
     driver = get_driver(settings.DRIVER_PATH, provider=settings.DRIVER_PROVIDER)
-    metadata = driver.get_metadata(keys)
+    metadata = filter_metadata(driver.get_metadata(keys), columns)
     metadata["keys"] = OrderedDict(zip(driver.key_names, keys))
     return metadata
+
+
+@trace("multiple_metadata_handler")
+def multiple_metadata(columns: Optional[List[str]], datasets: List[List[str]]) -> List[Dict[str, Any]]:
+    """Returns all metadata for multiple datasets"""
+    settings = get_settings()
+    driver = get_driver(settings.DRIVER_PATH, provider=settings.DRIVER_PROVIDER)
+    key_names = driver.key_names
+
+    out = []
+    for dataset in datasets:
+        metadata = filter_metadata(driver.get_metadata(dataset), columns)
+        metadata["keys"] = OrderedDict(zip(key_names, dataset))
+        out.append(metadata)
+
+    return out

--- a/terracotta/scripts/click_types.py
+++ b/terracotta/scripts/click_types.py
@@ -26,7 +26,7 @@ class PathlibPath(click.Path):
     """Converts a string to a pathlib.Path object"""
 
     def convert(self, *args: Any) -> pathlib.Path:
-        return pathlib.Path(super().convert(*args))
+        return pathlib.Path(str(super().convert(*args)))
 
 
 RasterPatternType = Tuple[List[str], Dict[Tuple[str, ...], str]]

--- a/terracotta/server/metadata.py
+++ b/terracotta/server/metadata.py
@@ -63,7 +63,7 @@ class MetadataColumnsSchema(Schema):
     @pre_load
     def validate_columns(
         self, data: Mapping[str, Any], **kwargs: Any
-    ) -> Dict[str, Any]:
+    ) -> Dict[str, Any] | Mapping[str, Any]:
         columns = data.get("columns")
 
         if columns:
@@ -148,7 +148,7 @@ def get_multiple_metadata() -> Response:
     from terracotta.handlers.metadata import multiple_metadata
 
     datasets_schema = MultipleMetadataDatasetsSchema()
-    datasets = datasets_schema.load(request.json).get("keys")
+    datasets = datasets_schema.load(request.json or {}).get("keys")
 
     columns_schema = MetadataColumnsSchema()
     columns = columns_schema.load(request.args).get("columns")

--- a/terracotta/server/metadata.py
+++ b/terracotta/server/metadata.py
@@ -61,7 +61,9 @@ class MetadataColumnsSchema(Schema):
     )
 
     @pre_load
-    def validate_columns(self, data: Mapping[str, Any], **kwargs: Any) -> Dict[str, Any]:
+    def validate_columns(
+        self, data: Mapping[str, Any], **kwargs: Any
+    ) -> Dict[str, Any]:
         columns = data.get("columns")
 
         if columns:
@@ -70,9 +72,7 @@ class MetadataColumnsSchema(Schema):
             try:
                 data["columns"] = json.loads(columns)
             except json.decoder.JSONDecodeError as exc:
-                raise ValidationError(
-                    "columns must be a JSON list"
-                ) from exc
+                raise ValidationError("columns must be a JSON list") from exc
 
         return data
 

--- a/terracotta/server/metadata.py
+++ b/terracotta/server/metadata.py
@@ -58,15 +58,13 @@ class CommaSeparatedListField(fields.Field):
             if value == "[]":
                 return []
 
-            return value[1:-1].split(', ')
+            return value[1:-1].split(", ")
         except ValueError:
             raise ValidationError("Invalid input for a list of values.")
 
 
 class MetadataColumnsSchema(Schema):
-    columns = CommaSeparatedListField(
-        description="Columns of dataset to be returned"
-    )
+    columns = CommaSeparatedListField(description="Columns of dataset to be returned")
 
 
 class MultipleMetadataDatasetsSchema(Schema):

--- a/terracotta/server/metadata.py
+++ b/terracotta/server/metadata.py
@@ -3,8 +3,8 @@
 Flask route to handle /metadata calls.
 """
 
-from marshmallow import Schema, fields, validate
-from flask import jsonify, Response
+from marshmallow import Schema, fields, validate, ValidationError
+from flask import jsonify, Response, request
 
 from terracotta.server.flask_api import METADATA_API
 
@@ -50,6 +50,37 @@ class MetadataSchema(Schema):
     )
 
 
+class CommaSeparatedListField(fields.Field):
+    def _deserialize(self, value, attr, data, **kwargs):
+        try:
+            assert value[0] == "[" and value[-1] == "]"
+
+            if value == "[]":
+                return []
+
+            return value[1:-1].split(', ')
+        except ValueError:
+            raise ValidationError("Invalid input for a list of values.")
+
+
+class MetadataColumnsSchema(Schema):
+    columns = CommaSeparatedListField(
+        description="Columns of dataset to be returned"
+    )
+
+
+class MultipleMetadataDatasetsSchema(Schema):
+    keys = fields.List(
+        fields.List(
+            fields.String(),
+            description="Keys identifying dataset",
+            required=True,
+        ),
+        required=True,
+        description="Array containing all available key combinations",
+    )
+
+
 @METADATA_API.route("/metadata/<path:keys>", methods=["GET"])
 def get_metadata(keys: str) -> Response:
     """Get metadata for given dataset
@@ -63,6 +94,8 @@ def get_metadata(keys: str) -> Response:
             description: Keys of dataset to retrieve metadata for (e.g. 'value1/value2')
             type: path
             required: true
+          - in: query
+            schema: MetadataColumnsSchema
         responses:
             200:
                 description: All metadata for given dataset
@@ -72,7 +105,45 @@ def get_metadata(keys: str) -> Response:
     """
     from terracotta.handlers.metadata import metadata
 
+    columns_schema = MetadataColumnsSchema()
+    columns = columns_schema.load(request.args).get("columns")
+
     parsed_keys = [key for key in keys.split("/") if key]
-    payload = metadata(parsed_keys)
-    schema = MetadataSchema()
+
+    payload = metadata(columns, parsed_keys)
+    schema = MetadataSchema(partial=columns is not None)
     return jsonify(schema.load(payload))
+
+
+@METADATA_API.route("/metadata", methods=["POST"])
+def get_multiple_metadata() -> Response:
+    """Get metadata for multiple datasets
+    ---
+    post:
+        summary: /metadata
+        description:
+            Retrieve metadata for multiple datasets, identified by the
+            body payload. Desired columns can be filtered using the ?columns
+            query.
+        parameters:
+          - in: query
+            schema: MetadataColumnsSchema
+          - in: body
+            schema: MultipleMetadataDatasetsSchema
+        responses:
+            200:
+                description: All metadata for given dataset
+                schema: MetadataSchema
+            404:
+                description: No dataset found for given key combination
+    """
+    from terracotta.handlers.metadata import multiple_metadata
+
+    datasets_schema = MultipleMetadataDatasetsSchema()
+    datasets = datasets_schema.load(request.json).get("keys")
+
+    columns_schema = MetadataColumnsSchema()
+    columns = columns_schema.load(request.args).get("columns")
+
+    schema = MetadataSchema(many=True, partial=columns is not None)
+    return jsonify(schema.load(multiple_metadata(columns, datasets)))

--- a/terracotta/server/metadata.py
+++ b/terracotta/server/metadata.py
@@ -145,7 +145,7 @@ def get_multiple_metadata() -> Response:
                 schema: MetadataSchema
             400:
                 description:
-                    If the MAX_POST_METADATA_KEYS (100 by default) limit is exceeded
+                    If the maximum number of requested datasets is exceeded
             404:
                 description: No dataset found for given key combination
     """

--- a/terracotta/server/metadata.py
+++ b/terracotta/server/metadata.py
@@ -143,6 +143,9 @@ def get_multiple_metadata() -> Response:
             200:
                 description: All metadata for given dataset
                 schema: MetadataSchema
+            400:
+                description:
+                    If the MAX_POST_METADATA_KEYS (100 by default) limit is exceeded
             404:
                 description: No dataset found for given key combination
     """

--- a/tests/handlers/test_metadata.py
+++ b/tests/handlers/test_metadata.py
@@ -5,3 +5,22 @@ def test_metadata_handler(use_testdb):
     md = metadata.metadata(ds)
     assert md
     assert md["metadata"] == ["extra_data"]
+
+
+def test_multiple_metadata_handler(use_testdb):
+    from terracotta.handlers import metadata, datasets
+
+    ds = datasets.datasets()
+    ds1 = list(ds[0].values())
+    ds2 = list(ds[1].values())
+
+    md = metadata.multiple_metadata(None, [ds1, ds2])
+
+    assert md
+    assert md[0]["metadata"] == ["extra_data"]
+    assert len(md) == 2
+
+    md = metadata.multiple_metadata(["metadata", "bounds"], [ds1, ds2])
+    assert md
+    assert len(md[0].keys()) == 3
+    assert all(k in md[0].keys() for k in ("metadata", "bounds", "keys"))

--- a/tests/handlers/test_metadata.py
+++ b/tests/handlers/test_metadata.py
@@ -2,9 +2,14 @@ def test_metadata_handler(use_testdb):
     from terracotta.handlers import metadata, datasets
 
     ds = datasets.datasets()[0]
-    md = metadata.metadata(ds)
+    md = metadata.metadata(None, ds)
     assert md
     assert md["metadata"] == ["extra_data"]
+
+    md = metadata.metadata(["metadata", "bounds"], ds)
+    assert md
+    assert len(md.keys()) == 3
+    assert all(k in md.keys() for k in ("metadata", "bounds", "keys"))
 
 
 def test_multiple_metadata_handler(use_testdb):

--- a/tests/server/test_flask_api.py
+++ b/tests/server/test_flask_api.py
@@ -93,9 +93,7 @@ def test_get_metadata_nonexisting(client, use_testdb):
 def test_post_metadata(client, use_testdb):
     rv = client.post(
         "/metadata",
-        json={
-            "keys": [["val11", "x", "val12"], ["val21", "x", "val22"]]
-        },
+        json={"keys": [["val11", "x", "val12"], ["val21", "x", "val22"]]},
     )
 
     assert rv.status_code == 200
@@ -105,9 +103,7 @@ def test_post_metadata(client, use_testdb):
 def test_post_metadata_specific_columns(client, use_testdb):
     rv = client.post(
         '/metadata?columns=["bounds", "range"]',
-        json={
-            "keys": [["val11", "x", "val12"], ["val21", "x", "val22"]]
-        },
+        json={"keys": [["val11", "x", "val12"], ["val21", "x", "val22"]]},
     )
 
     assert rv.status_code == 200

--- a/tests/server/test_flask_api.py
+++ b/tests/server/test_flask_api.py
@@ -117,7 +117,7 @@ def test_post_metadata_errors(debug_client, use_non_writable_testdb):
     with pytest.raises(marshmallow.ValidationError):
         debug_client.post(
             '/metadata?columns=["range]',
-            json={"keys": [["val11", "x", "val12"], ["val21", "x", "val22"]], },
+            json={"keys": [["val11", "x", "val12"], ["val21", "x", "val22"]]},
         )
 
     with pytest.raises(KeyError):

--- a/tests/server/test_flask_api.py
+++ b/tests/server/test_flask_api.py
@@ -111,6 +111,22 @@ def test_post_metadata_specific_columns(client, use_testdb):
     assert set(json.loads(rv.data)[0].keys()) == {"bounds", "range", "keys"}
 
 
+def test_post_metadata_errors(debug_client, use_non_writable_testdb):
+    import marshmallow
+
+    with pytest.raises(marshmallow.ValidationError):
+        debug_client.post(
+            '/metadata?columns=["range]',
+            json={"keys": [["val11", "x", "val12"], ["val21", "x", "val22"]], },
+        )
+
+    with pytest.raises(KeyError):
+        debug_client.post(
+            '/metadata?columns=["invalid"]',
+            json={"keys": [["val11", "x", "val12"], ["val21", "x", "val22"]]},
+        )
+
+
 def test_get_datasets(client, use_testdb):
     rv = client.get("/datasets")
     assert rv.status_code == 200

--- a/tests/server/test_flask_api.py
+++ b/tests/server/test_flask_api.py
@@ -112,12 +112,25 @@ def test_post_metadata_specific_columns(client, use_testdb):
 
 
 def test_post_metadata_errors(debug_client, use_non_writable_testdb):
+    from terracotta import exceptions
     import marshmallow
 
     with pytest.raises(marshmallow.ValidationError):
         debug_client.post(
             '/metadata?columns=["range]',
             json={"keys": [["val11", "x", "val12"], ["val21", "x", "val22"]]},
+        )
+
+    with pytest.raises(exceptions.InvalidArgumentsError):
+        debug_client.post(
+            '/metadata?columns=["range"]',
+            json={"keys": [["val11", "x", "val12"] for _ in range(101)]},
+        )
+
+    with pytest.raises(exceptions.InvalidArgumentsError):
+        debug_client.post(
+            '/metadata?columns=["range"]',
+            json="Invalid JSON",
         )
 
     with pytest.raises(KeyError):

--- a/tests/server/test_flask_api.py
+++ b/tests/server/test_flask_api.py
@@ -90,6 +90,31 @@ def test_get_metadata_nonexisting(client, use_testdb):
     assert rv.status_code == 404
 
 
+def test_post_metadata(client, use_testdb):
+    rv = client.post(
+        "/metadata",
+        json={
+            "keys": [["val11", "x", "val12"], ["val21", "x", "val22"]]
+        },
+    )
+
+    assert rv.status_code == 200
+    assert len(json.loads(rv.data)) == 2
+
+
+def test_post_metadata_specific_columns(client, use_testdb):
+    rv = client.post(
+        '/metadata?columns=["bounds", "range"]',
+        json={
+            "keys": [["val11", "x", "val12"], ["val21", "x", "val22"]]
+        },
+    )
+
+    assert rv.status_code == 200
+    assert len(json.loads(rv.data)) == 2
+    assert set(json.loads(rv.data)[0].keys()) == {"bounds", "range", "keys"}
+
+
 def test_get_datasets(client, use_testdb):
     rv = client.get("/datasets")
     assert rv.status_code == 200


### PR DESCRIPTION
This PR closes https://github.com/DHI-GRAS/terracotta/issues/309

This PR provides the ability for users to send a `POST` request to the `/metadata` endpoint, where they can filter the columns has path parameters, e.g. `POST /metadata/bounds`, which will only return the bounds (and the keys used, which is default on all)

Notes:
- I had a challenge with the naming convention and the structure itself. Should this endpoint be in its own file, or share a file with the `GET` request?
- Should the methods be called `post_metadata` or `get_multiple_metadata` or `get_metadatas` or something else..? For now, I named the endpoint `post_metadata` and every other method `get_multiple_metadata`.
- Should the user be able to specify e.g. `bounds_south` as a column or should we only allow them to specify `bounds`? (same with `range` & `min/max`). For now, I *have* added this functionality.
- Please let me know if you have a better way to do the specific-decoding handling instead of the added `_decode_specific_data` function.
- Please let me know as well if any variable names/types should be changed.
- What should we do in the case of lazy-loading? Should we allow the user to lazy-load and generate metadata for **everything**? For now, I excluded this functionality as it could take a very long time. Let me know if you'd like this added.

Please let me know if you have any feedback, as that is very appreciated. I'm excited to see this feature be used.