### PR TITLE
Add rgb_range percentile support

### DIFF
--- a/terracotta/handlers/rgb.py
+++ b/terracotta/handlers/rgb.py
@@ -91,11 +91,12 @@ def rgb(
             band_stretch_range = list(metadata["range"])
             scale_min, scale_max = band_stretch_override
 
+            percentiles = metadata.get("percentiles", [])
             if scale_min is not None:
-                band_stretch_range[0] = image.get_stretch_scale(scale_min, metadata)
+                band_stretch_range[0] = image.get_stretch_scale(scale_min, percentiles)
 
             if scale_max is not None:
-                band_stretch_range[1] = image.get_stretch_scale(scale_max, metadata)
+                band_stretch_range[1] = image.get_stretch_scale(scale_max, percentiles)
 
             if band_stretch_range[1] < band_stretch_range[0]:
                 raise exceptions.InvalidArgumentsError(

--- a/terracotta/handlers/rgb.py
+++ b/terracotta/handlers/rgb.py
@@ -12,7 +12,7 @@ from terracotta.profile import trace
 
 NumberOrString = TypeVar("NumberOrString", int, float, str)
 ListOfRanges = Sequence[
-    Optional[Tuple[Optional[image.NumberOrString], Optional[image.NumberOrString]]]
+    Optional[Tuple[Optional[NumberOrString], Optional[NumberOrString]]]
 ]
 
 

--- a/terracotta/handlers/singleband.py
+++ b/terracotta/handlers/singleband.py
@@ -14,7 +14,7 @@ from terracotta.profile import trace
 Number = TypeVar("Number", int, float)
 NumberOrString = TypeVar("NumberOrString", int, float, str)
 ListOfRanges = Sequence[
-    Optional[Tuple[Optional[image.NumberOrString], Optional[image.NumberOrString]]]
+    Optional[Tuple[Optional[NumberOrString], Optional[NumberOrString]]]
 ]
 RGBA = Tuple[Number, Number, Number, Number]
 

--- a/terracotta/handlers/singleband.py
+++ b/terracotta/handlers/singleband.py
@@ -12,6 +12,10 @@ from terracotta import get_settings, get_driver, image, xyz
 from terracotta.profile import trace
 
 Number = TypeVar("Number", int, float)
+NumberOrString = TypeVar("NumberOrString", int, float, str)
+ListOfRanges = Sequence[
+    Optional[Tuple[Optional[image.NumberOrString], Optional[image.NumberOrString]]]
+]
 RGBA = Tuple[Number, Number, Number, Number]
 
 
@@ -21,7 +25,7 @@ def singleband(
     tile_xyz: Optional[Tuple[int, int, int]] = None,
     *,
     colormap: Union[str, Mapping[Number, RGBA], None] = None,
-    stretch_range: Optional[Tuple[Number, Number]] = None,
+    stretch_range: Optional[Tuple[NumberOrString, NumberOrString]] = None,
     tile_size: Optional[Tuple[int, int]] = None
 ) -> BinaryIO:
     """Return singleband image as PNG"""
@@ -60,10 +64,10 @@ def singleband(
         stretch_range_ = list(metadata["range"])
 
         if stretch_min is not None:
-            stretch_range_[0] = stretch_min
+            stretch_range_[0] = image.get_stretch_scale(stretch_min, metadata)
 
         if stretch_max is not None:
-            stretch_range_[1] = stretch_max
+            stretch_range_[1] = image.get_stretch_scale(stretch_max, metadata)
 
         cmap_or_palette = cast(Optional[str], colormap)
         out = image.to_uint8(tile_data, *stretch_range_)

--- a/terracotta/handlers/singleband.py
+++ b/terracotta/handlers/singleband.py
@@ -63,11 +63,12 @@ def singleband(
         # determine stretch range from metadata and arguments
         stretch_range_ = list(metadata["range"])
 
+        percentiles = metadata.get("percentiles", [])
         if stretch_min is not None:
-            stretch_range_[0] = image.get_stretch_scale(stretch_min, metadata)
+            stretch_range_[0] = image.get_stretch_scale(stretch_min, percentiles)
 
         if stretch_max is not None:
-            stretch_range_[1] = image.get_stretch_scale(stretch_max, metadata)
+            stretch_range_[1] = image.get_stretch_scale(stretch_max, percentiles)
 
         cmap_or_palette = cast(Optional[str], colormap)
         out = image.to_uint8(tile_data, *stretch_range_)

--- a/terracotta/image.py
+++ b/terracotta/image.py
@@ -182,7 +182,9 @@ def label(data: Array, labels: Sequence[Number]) -> Array:
     return out_data
 
 
-def get_stretch_scale(scale: NumberOrString, metadata: Dict[str, Any]) -> int | float:
+def get_stretch_scale(
+    scale: NumberOrString, metadata: Dict[str, Any]
+) -> Union[int, float]:
     if isinstance(scale, (int, float)):
         return scale
     if isinstance(scale, str):

--- a/terracotta/image.py
+++ b/terracotta/image.py
@@ -3,7 +3,7 @@
 Utilities to create and manipulate images.
 """
 
-from typing import Any, Dict, Sequence, Tuple, TypeVar, Union
+from typing import List, Sequence, Tuple, TypeVar, Union
 from typing.io import BinaryIO
 
 from io import BytesIO
@@ -183,7 +183,7 @@ def label(data: Array, labels: Sequence[Number]) -> Array:
 
 
 def get_stretch_scale(
-    scale: NumberOrString, metadata: Dict[str, Any]
+    scale: NumberOrString, percentiles: List[int]
 ) -> Union[int, float]:
     if isinstance(scale, (int, float)):
         return scale
@@ -197,8 +197,8 @@ def get_stretch_scale(
                     f"Invalid percentile value: {scale}"
                 )
 
-            if 0 <= percentile < len(metadata["percentiles"]):
-                return metadata["percentiles"][percentile]
+            if 0 <= percentile < len(percentiles):
+                return percentiles[percentile]
 
             raise exceptions.InvalidArgumentsError(
                 f"Invalid percentile, out of range: {scale}"

--- a/terracotta/image.py
+++ b/terracotta/image.py
@@ -189,7 +189,7 @@ def get_stretch_scale(scale: NumberOrString, metadata: Dict[str, Any]) -> int | 
         # can be a percentile
         if scale.startswith("p"):
             try:
-                percentile = int(scale[1:]) - 1
+                percentile = int(scale[1:])
             except ValueError:
                 raise exceptions.InvalidArgumentsError(
                     f"Invalid percentile value: {scale}"

--- a/terracotta/image.py
+++ b/terracotta/image.py
@@ -3,7 +3,7 @@
 Utilities to create and manipulate images.
 """
 
-from typing import Sequence, Tuple, TypeVar, Union
+from typing import Any, Dict, Sequence, Tuple, TypeVar, Union
 from typing.io import BinaryIO
 
 from io import BytesIO
@@ -15,6 +15,7 @@ from terracotta.profile import trace
 from terracotta import exceptions, get_settings
 
 Number = TypeVar("Number", int, float)
+NumberOrString = TypeVar("NumberOrString", int, float, str)
 RGBA = Tuple[Number, Number, Number, Number]
 Palette = Sequence[RGBA]
 Array = Union[np.ndarray, np.ma.MaskedArray]
@@ -179,3 +180,26 @@ def label(data: Array, labels: Sequence[Number]) -> Array:
         out_data[data == label] = i
 
     return out_data
+
+
+def get_stretch_scale(scale: NumberOrString, metadata: Dict[str, Any]) -> int | float:
+    if isinstance(scale, (int, float)):
+        return scale
+    if isinstance(scale, str):
+        # can be a percentile
+        if scale.startswith("p"):
+            try:
+                percentile = int(scale[1:]) - 1
+            except ValueError:
+                raise exceptions.InvalidArgumentsError(
+                    f"Invalid percentile value: {scale}"
+                )
+
+            if 0 <= percentile < len(metadata["percentiles"]):
+                return metadata["percentiles"][percentile]
+
+            raise exceptions.InvalidArgumentsError(
+                f"Invalid percentile, out of range: {scale}"
+            )
+
+    raise exceptions.InvalidArgumentsError(f"Invalid scale value: {scale}")

--- a/terracotta/server/fields.py
+++ b/terracotta/server/fields.py
@@ -27,11 +27,8 @@ class StringOrNumber(fields.Field):
 
 
 def validate_stretch_range(data: Any) -> None:
-    if isinstance(data, str) and data.startswith("p"):
+    if isinstance(data, str):
         if not re.match("^p\\d+$", data):
             raise ValidationError("Percentile format is `p<digits>`")
-    else:
-        try:
-            float(data)
-        except ValueError:
-            raise ValidationError("Must be a number")
+    elif not isinstance(data, (int, float)):
+        raise ValidationError("Must be a number or string like `p<digits>`")

--- a/terracotta/server/fields.py
+++ b/terracotta/server/fields.py
@@ -10,8 +10,14 @@ from typing import Any, Union
 
 
 class StringOrNumber(fields.Field):
+    """
+    Marshmallow type that can be either a string or a number.
+    Uses marshmallow's default serialization/deserialization
+    for `String` or a `Float` depending on the value type.
+    """
+
     def _serialize(
-        self, value: Any, attr: Any, obj: Any, **kwargs: Any
+        self, value: Union[str, bytes, int, float], attr: Any, obj: Any, **kwargs: Any
     ) -> Union[str, float, None]:
         if isinstance(value, (str, bytes)):
             return fields.String()._serialize(value, attr, obj, **kwargs)
@@ -21,7 +27,7 @@ class StringOrNumber(fields.Field):
             raise ValidationError("Must be a string or a number")
 
     def _deserialize(
-        self, value: Any, attr: Any, data: Any, **kwargs: Any
+        self, value: Union[str, bytes, int, float], attr: Any, data: Any, **kwargs: Any
     ) -> Union[str, float, None]:
         if isinstance(value, (str, bytes)):
             return fields.String()._deserialize(value, attr, data, **kwargs)
@@ -32,6 +38,10 @@ class StringOrNumber(fields.Field):
 
 
 def validate_stretch_range(data: Any) -> None:
+    """
+    Validates that the stretch range is in the format `p&lt;digits&gt;`
+    when a string is used.
+    """
     if isinstance(data, str):
         if not re.match("^p\\d+$", data):
             raise ValidationError("Percentile format is `p<digits>`")

--- a/terracotta/server/fields.py
+++ b/terracotta/server/fields.py
@@ -1,13 +1,18 @@
+"""server/fields.py
+
+Custom marshmallow fields for the server API.
+"""
+
 import re
 from marshmallow import ValidationError, fields
 
-from typing import Any
+from typing import Any, Union
 
 
 class StringOrNumber(fields.Field):
     def _serialize(
         self, value: Any, attr: Any, obj: Any, **kwargs: Any
-    ) -> str | float | None:
+    ) -> Union[str, float, None]:
         if isinstance(value, (str, bytes)):
             return fields.String()._serialize(value, attr, obj, **kwargs)
         elif isinstance(value, (int, float)):
@@ -17,7 +22,7 @@ class StringOrNumber(fields.Field):
 
     def _deserialize(
         self, value: Any, attr: Any, data: Any, **kwargs: Any
-    ) -> str | float | None:
+    ) -> Union[str, float, None]:
         if isinstance(value, (str, bytes)):
             return fields.String()._deserialize(value, attr, data, **kwargs)
         elif isinstance(value, (int, float)):

--- a/terracotta/server/fields.py
+++ b/terracotta/server/fields.py
@@ -39,7 +39,7 @@ class StringOrNumber(fields.Field):
 
 def validate_stretch_range(data: Any) -> None:
     """
-    Validates that the stretch range is in the format `p&lt;digits&gt;`
+    Validates that the stretch range is in the format `p<digits>`
     when a string is used.
     """
     if isinstance(data, str):

--- a/terracotta/server/fields.py
+++ b/terracotta/server/fields.py
@@ -30,5 +30,3 @@ def validate_stretch_range(data: Any) -> None:
     if isinstance(data, str):
         if not re.match("^p\\d+$", data):
             raise ValidationError("Percentile format is `p<digits>`")
-    elif not isinstance(data, (int, float)):
-        raise ValidationError("Must be a number or string like `p<digits>`")

--- a/terracotta/server/fields.py
+++ b/terracotta/server/fields.py
@@ -1,0 +1,37 @@
+import re
+from marshmallow import ValidationError, fields
+
+from typing import Any
+
+
+class StringOrNumber(fields.Field):
+    def _serialize(
+        self, value: Any, attr: Any, obj: Any, **kwargs: Any
+    ) -> str | float | None:
+        if isinstance(value, (str, bytes)):
+            return fields.String()._serialize(value, attr, obj, **kwargs)
+        elif isinstance(value, (int, float)):
+            return fields.Float()._serialize(value, attr, obj, **kwargs)
+        else:
+            raise ValidationError("Must be a string or a number")
+
+    def _deserialize(
+        self, value: Any, attr: Any, data: Any, **kwargs: Any
+    ) -> str | float | None:
+        if isinstance(value, (str, bytes)):
+            return fields.String()._deserialize(value, attr, data, **kwargs)
+        elif isinstance(value, (int, float)):
+            return fields.Float()._deserialize(value, attr, data, **kwargs)
+        else:
+            raise ValidationError("Must be a string or a number")
+
+
+def validate_stretch_range(data: Any) -> None:
+    if isinstance(data, str) and data.startswith("p"):
+        if not re.match("^p\\d+$", data):
+            raise ValidationError("Percentile format is `p<digits>`")
+    else:
+        try:
+            float(data)
+        except ValueError:
+            raise ValidationError("Must be a number")

--- a/terracotta/server/rgb.py
+++ b/terracotta/server/rgb.py
@@ -37,8 +37,8 @@ class RGBOptionSchema(Schema):
         description=(
             "Stretch range [min, max] to use for the red band as JSON array. "
             "Min and max may be numbers to use as absolute range, or strings "
-            "of the format p<int> with an integer between 0 and 100 to use "
-            "percentiles of the image instead. "
+            "of the format `p&lt;digits&gt;` with an integer between 0 and 100 "
+            "to use percentiles of the image instead. "
             "Null values indicate global minimum / maximum."
         ),
     )
@@ -50,8 +50,8 @@ class RGBOptionSchema(Schema):
         description=(
             "Stretch range [min, max] to use for the gren band as JSON array. "
             "Min and max may be numbers to use as absolute range, or strings "
-            "of the format p<int> with an integer between 0 and 100 to use "
-            "percentiles of the image instead. "
+            "of the format `p&lt;digits&gt;` with an integer between 0 and 100 "
+            "to use percentiles of the image instead. "
             "Null values indicate global minimum / maximum."
         ),
     )
@@ -63,8 +63,8 @@ class RGBOptionSchema(Schema):
         description=(
             "Stretch range [min, max] to use for the blue band as JSON array. "
             "Min and max may be numbers to use as absolute range, or strings "
-            "of the format p<int> with an integer between 0 and 100 to use "
-            "percentiles of the image instead. "
+            "of the format `p&lt;digits&gt;` with an integer between 0 and 100 "
+            "to use percentiles of the image instead. "
             "Null values indicate global minimum / maximum."
         ),
     )

--- a/terracotta/server/rgb.py
+++ b/terracotta/server/rgb.py
@@ -37,7 +37,7 @@ class RGBOptionSchema(Schema):
         description=(
             "Stretch range [min, max] to use for the red band as JSON array. "
             "Min and max may be numbers to use as absolute range, or strings "
-            "of the format `p&lt;digits&gt;` with an integer between 0 and 100 "
+            "of the format `p<digits>` with an integer between 0 and 100 "
             "to use percentiles of the image instead. "
             "Null values indicate global minimum / maximum."
         ),
@@ -50,7 +50,7 @@ class RGBOptionSchema(Schema):
         description=(
             "Stretch range [min, max] to use for the gren band as JSON array. "
             "Min and max may be numbers to use as absolute range, or strings "
-            "of the format `p&lt;digits&gt;` with an integer between 0 and 100 "
+            "of the format `p<digits>` with an integer between 0 and 100 "
             "to use percentiles of the image instead. "
             "Null values indicate global minimum / maximum."
         ),
@@ -63,7 +63,7 @@ class RGBOptionSchema(Schema):
         description=(
             "Stretch range [min, max] to use for the blue band as JSON array. "
             "Min and max may be numbers to use as absolute range, or strings "
-            "of the format `p&lt;digits&gt;` with an integer between 0 and 100 "
+            "of the format `p<digits>` with an integer between 0 and 100 "
             "to use percentiles of the image instead. "
             "Null values indicate global minimum / maximum."
         ),

--- a/terracotta/server/rgb.py
+++ b/terracotta/server/rgb.py
@@ -29,25 +29,34 @@ class RGBOptionSchema(Schema):
     g = fields.String(required=True, description="Key value for green band")
     b = fields.String(required=True, description="Key value for blue band")
     r_range = fields.List(
-        fields.Number(allow_none=True),
+        fields.String(allow_none=True, validate=validate.Regexp("^p?(\d*\.)?\d+$")),
         validate=validate.Length(equal=2),
         example="[0,1]",
         missing=None,
-        description="Stretch range [min, max] to use for red band as JSON array",
+        description=(
+            "Stretch range [min, max] to use for red band as JSON array, "
+            "prefix with `p` for percentile"
+        ),
     )
     g_range = fields.List(
-        fields.Number(allow_none=True),
+        fields.String(allow_none=True, validate=validate.Regexp("^p?(\d*\.)?\d+$")),
         validate=validate.Length(equal=2),
         example="[0,1]",
         missing=None,
-        description="Stretch range [min, max] to use for green band as JSON array",
+        description=(
+            "Stretch range [min, max] to use for red band as JSON array, "
+            "prefix with `p` for percentile"
+        ),
     )
     b_range = fields.List(
-        fields.Number(allow_none=True),
+        fields.String(allow_none=True, validate=validate.Regexp("^p?(\d*\.)?\d+$")),
         validate=validate.Length(equal=2),
         example="[0,1]",
         missing=None,
-        description="Stretch range [min, max] to use for blue band as JSON array",
+        description=(
+            "Stretch range [min, max] to use for red band as JSON array, "
+            "prefix with `p` for percentile"
+        ),
     )
     tile_size = fields.List(
         fields.Integer(),

--- a/terracotta/server/rgb.py
+++ b/terracotta/server/rgb.py
@@ -35,9 +35,11 @@ class RGBOptionSchema(Schema):
         example="[0,1]",
         missing=None,
         description=(
-            "Stretch range [min, max] to use for red band as JSON array. Min and max may be "
-            "numbers to use as absolute range, or strings of the format p<int> "
-            "with an integer between 0 and 100 to use percentiles of the image instead."
+            "Stretch range [min, max] to use for the red band as JSON array. "
+            "Min and max may be numbers to use as absolute range, or strings "
+            "of the format p<int> with an integer between 0 and 100 to use "
+            "percentiles of the image instead. "
+            "Null values indicate global minimum / maximum."
         ),
     )
     g_range = fields.List(
@@ -46,8 +48,11 @@ class RGBOptionSchema(Schema):
         example="[0,1]",
         missing=None,
         description=(
-            "Stretch range [min, max] to use for red band as JSON array, "
-            "prefix with `p` for percentile"
+            "Stretch range [min, max] to use for the gren band as JSON array. "
+            "Min and max may be numbers to use as absolute range, or strings "
+            "of the format p<int> with an integer between 0 and 100 to use "
+            "percentiles of the image instead. "
+            "Null values indicate global minimum / maximum."
         ),
     )
     b_range = fields.List(
@@ -56,8 +61,11 @@ class RGBOptionSchema(Schema):
         example="[0,1]",
         missing=None,
         description=(
-            "Stretch range [min, max] to use for red band as JSON array, "
-            "prefix with `p` for percentile"
+            "Stretch range [min, max] to use for the blue band as JSON array. "
+            "Min and max may be numbers to use as absolute range, or strings "
+            "of the format p<int> with an integer between 0 and 100 to use "
+            "percentiles of the image instead. "
+            "Null values indicate global minimum / maximum."
         ),
     )
     tile_size = fields.List(

--- a/terracotta/server/singleband.py
+++ b/terracotta/server/singleband.py
@@ -39,8 +39,13 @@ class SinglebandOptionSchema(Schema):
         StringOrNumber(allow_none=True, validate=validate_stretch_range),
         validate=validate.Length(equal=2),
         example="[0,1]",
-        description="Stretch range to use as JSON array, uses full range by default. "
-        "Null values indicate global minimum / maximum.",
+        description=(
+            "Stretch range [min, max] to use for the band as JSON array. "
+            "Min and max may be numbers to use as absolute range, or strings "
+            "of the format p<int> with an integer between 0 and 100 to use "
+            "percentiles of the image instead. "
+            "Null values indicate global minimum / maximum."
+        ),
         missing=None,
     )
 

--- a/terracotta/server/singleband.py
+++ b/terracotta/server/singleband.py
@@ -42,8 +42,8 @@ class SinglebandOptionSchema(Schema):
         description=(
             "Stretch range [min, max] to use as JSON array. "
             "Min and max may be numbers to use as absolute range, or strings "
-            "of the format p<int> with an integer between 0 and 100 to use "
-            "percentiles of the image instead. "
+            "of the format `p&lt;digits&gt;` with an integer between 0 and 100 "
+            "to use percentiles of the image instead. "
             "Null values indicate global minimum / maximum."
         ),
         missing=None,

--- a/terracotta/server/singleband.py
+++ b/terracotta/server/singleband.py
@@ -42,7 +42,7 @@ class SinglebandOptionSchema(Schema):
         description=(
             "Stretch range [min, max] to use as JSON array. "
             "Min and max may be numbers to use as absolute range, or strings "
-            "of the format `p&lt;digits&gt;` with an integer between 0 and 100 "
+            "of the format `p<digits>` with an integer between 0 and 100 "
             "to use percentiles of the image instead. "
             "Null values indicate global minimum / maximum."
         ),

--- a/terracotta/server/singleband.py
+++ b/terracotta/server/singleband.py
@@ -40,7 +40,7 @@ class SinglebandOptionSchema(Schema):
         validate=validate.Length(equal=2),
         example="[0,1]",
         description=(
-            "Stretch range [min, max] to use for the band as JSON array. "
+            "Stretch range [min, max] to use as JSON array. "
             "Min and max may be numbers to use as absolute range, or strings "
             "of the format p<int> with an integer between 0 and 100 to use "
             "percentiles of the image instead. "

--- a/terracotta/server/singleband.py
+++ b/terracotta/server/singleband.py
@@ -17,6 +17,7 @@ from marshmallow import (
 )
 from flask import request, send_file, Response
 
+from terracotta.server.fields import StringOrNumber, validate_stretch_range
 from terracotta.server.flask_api import TILE_API
 from terracotta.cmaps import AVAILABLE_CMAPS
 
@@ -35,7 +36,7 @@ class SinglebandOptionSchema(Schema):
         unknown = EXCLUDE
 
     stretch_range = fields.List(
-        fields.Number(allow_none=True),
+        StringOrNumber(allow_none=True, validate=validate_stretch_range),
         validate=validate.Length(equal=2),
         example="[0,1]",
         description="Stretch range to use as JSON array, uses full range by default. "

--- a/tests/handlers/test_rgb.py
+++ b/tests/handlers/test_rgb.py
@@ -74,10 +74,13 @@ def test_rgb_lowzoom(use_testdb, raster_file, raster_file_xyz_lowzoom):
 
 
 @pytest.mark.parametrize(
-    "stretch_range", [
-        [0, 20000], [10000, 20000], [-50000, 50000], [100, 100],
-        ["0", "20000"], ["10000", "20000"], ["-50000", "50000"], ["100", "100"],
-    ]
+    "stretch_range",
+    [
+        [0, 20000],
+        [10000, 20000],
+        [-50000, 50000],
+        [100, 100],
+    ],
 )
 def test_rgb_stretch(stretch_range, use_testdb, testdb, raster_file_xyz):
     import terracotta
@@ -109,7 +112,6 @@ def test_rgb_stretch(stretch_range, use_testdb, testdb, raster_file_xyz):
     valid_img = img_data[valid_mask]
     valid_data = tile_data.compressed()
 
-    stretch_range = [float(stretch_range[0]), float(stretch_range[1])]
     assert np.all(valid_img[valid_data < stretch_range[0]] == 1)
     stretch_range_mask = (valid_data > stretch_range[0]) & (
         valid_data < stretch_range[1]
@@ -161,7 +163,10 @@ def test_rgb_percentile_stretch(use_testdb, testdb, raster_file_xyz):
         )
         band_metadata = driver.get_metadata(ds_keys)
 
-        stretch_range = [band_metadata["percentiles"][1], band_metadata["percentiles"][97]]
+        stretch_range = [
+            band_metadata["percentiles"][1],
+            band_metadata["percentiles"][97],
+        ]
 
     # filter transparent values
     valid_mask = ~tile_data.mask

--- a/tests/handlers/test_rgb.py
+++ b/tests/handlers/test_rgb.py
@@ -74,7 +74,10 @@ def test_rgb_lowzoom(use_testdb, raster_file, raster_file_xyz_lowzoom):
 
 
 @pytest.mark.parametrize(
-    "stretch_range", [[0, 20000], [10000, 20000], [-50000, 50000], [100, 100]]
+    "stretch_range", [
+        [0, 20000], [10000, 20000], [-50000, 50000], [100, 100],
+        ["0", "20000"], ["10000", "20000"], ["-50000", "50000"], ["100", "100"],
+    ]
 )
 def test_rgb_stretch(stretch_range, use_testdb, testdb, raster_file_xyz):
     import terracotta
@@ -106,6 +109,7 @@ def test_rgb_stretch(stretch_range, use_testdb, testdb, raster_file_xyz):
     valid_img = img_data[valid_mask]
     valid_data = tile_data.compressed()
 
+    stretch_range = [float(stretch_range[0]), float(stretch_range[1])]
     assert np.all(valid_img[valid_data < stretch_range[0]] == 1)
     stretch_range_mask = (valid_data > stretch_range[0]) & (
         valid_data < stretch_range[1]
@@ -129,6 +133,50 @@ def test_rgb_invalid_stretch(use_testdb, raster_file_xyz):
             raster_file_xyz,
             stretch_ranges=[stretch_range] * 3,
         )
+
+
+def test_rgb_percentile_stretch(use_testdb, testdb, raster_file_xyz):
+    import terracotta
+    from terracotta.xyz import get_tile_data
+    from terracotta.handlers import rgb
+
+    ds_keys = ["val21", "x", "val22"]
+    bands = ["val22", "val23", "val24"]
+    pct_stretch_range = ["p2", "p98"]
+
+    raw_img = rgb.rgb(
+        ds_keys[:2],
+        bands,
+        raster_file_xyz,
+        stretch_ranges=[pct_stretch_range] * 3,
+    )
+    img_data = np.asarray(Image.open(raw_img))[..., 0]
+
+    # get unstretched data to compare to
+    driver = terracotta.get_driver(testdb)
+
+    with driver.connect():
+        tile_data = get_tile_data(
+            driver, ds_keys, tile_xyz=raster_file_xyz, tile_size=img_data.shape
+        )
+        band_metadata = driver.get_metadata(ds_keys)
+
+        stretch_range = [band_metadata["percentiles"][1], band_metadata["percentiles"][97]]
+
+    # filter transparent values
+    valid_mask = ~tile_data.mask
+    assert np.all(img_data[~valid_mask] == 0)
+
+    valid_img = img_data[valid_mask]
+    valid_data = tile_data.compressed()
+
+    assert np.all(valid_img[valid_data < stretch_range[0]] == 1)
+    stretch_range_mask = (valid_data > stretch_range[0]) & (
+        valid_data < stretch_range[1]
+    )
+    assert np.all(valid_img[stretch_range_mask] >= 1)
+    assert np.all(valid_img[stretch_range_mask] <= 255)
+    assert np.all(valid_img[valid_data > stretch_range[1]] == 255)
 
 
 def test_rgb_preview(use_testdb):

--- a/tests/handlers/test_singleband.py
+++ b/tests/handlers/test_singleband.py
@@ -3,6 +3,8 @@ import numpy as np
 
 import pytest
 
+from terracotta import exceptions
+
 
 @pytest.mark.parametrize("resampling_method", ["nearest", "linear", "cubic", "average"])
 def test_singleband_handler(use_testdb, raster_file_xyz, resampling_method):
@@ -196,3 +198,30 @@ def test_singleband_stretch_percentile(use_testdb, testdb, raster_file_xyz):
     assert np.all(valid_img[stretch_range_mask] >= 1)
     assert np.all(valid_img[stretch_range_mask] <= 255)
     assert np.all(valid_img[valid_data > stretch_range[1]] == 255)
+
+
+@pytest.mark.parametrize(
+    "stretch_range_params",
+    [
+        ["s2", "p98", "Invalid scale value"],
+        ["pp2", "p98", "Invalid percentile value"],
+        ["p", "p98", "Invalid percentile value"],
+        ["2", "p8", "Invalid scale value"],
+        [{}, "p98", "Invalid scale value"],
+        ["p-2", "p98", "Invalid percentile, out of range"],
+        ["p2", "p298", "Invalid percentile, out of range"],
+    ],
+)
+def test_rgb_invalid_percentiles(use_testdb, stretch_range_params):
+    from terracotta.handlers import singleband
+
+    ds_keys = ["val21", "x", "val22"]
+
+    stretch_range = stretch_range_params[:2]
+
+    with pytest.raises(exceptions.InvalidArgumentsError) as err:
+        singleband.singleband(
+            ds_keys,
+            stretch_range=stretch_range,
+        )
+    assert stretch_range_params[2] in str(err.value)

--- a/tests/server/test_fields.py
+++ b/tests/server/test_fields.py
@@ -1,0 +1,42 @@
+from marshmallow import ValidationError
+import pytest
+from terracotta.server.singleband import SinglebandOptionSchema
+
+
+@pytest.mark.parametrize(
+    "args, expected",
+    [("[0, 1]", [0, 1]), ('["p2", "p28"]', ["p2", "p28"]), (None, None)],
+)
+def test_serde(args, expected):
+    args = {"stretch_range": args}
+    option_schema = SinglebandOptionSchema()
+    loaded = option_schema.load(args)
+    assert loaded["stretch_range"] == expected
+    dumped = option_schema.dump(loaded)
+    assert dumped["stretch_range"] == expected
+
+
+def test_serde_validation():
+    option_schema = SinglebandOptionSchema()
+    with pytest.raises(ValidationError) as exc_info:
+        args = {"stretch_range": '["t2", "p28"]'}
+        option_schema.load(args)
+    assert "Percentile format is `p<digits>`" in str(exc_info.value)
+
+    with pytest.raises(ValidationError) as exc_info:
+        args = {"stretch_range": '[{}, "p28"]'}
+        option_schema.load(args)
+    assert "Must be a string or a number" in str(exc_info.value)
+
+
+def test_serde_bad_type():
+    option_schema = SinglebandOptionSchema()
+    with pytest.raises(ValidationError) as exc_info:
+        dump_args = {"stretch_range": [0, {"bad": "type"}]}
+        option_schema.dump(dump_args)
+    assert "Must be a string or a number" in str(exc_info.value)
+
+    with pytest.raises(ValidationError) as exc_info:
+        load_args = {"stretch_range": '[0, {"bad": "type"}]'}
+        option_schema.load(load_args)
+    assert "Must be a string or a number" in str(exc_info.value)

--- a/tests/server/test_flask_api.py
+++ b/tests/server/test_flask_api.py
@@ -3,6 +3,7 @@ import json
 import urllib.parse
 
 from PIL import Image
+import marshmallow
 import numpy as np
 
 import pytest
@@ -562,3 +563,27 @@ def test_get_spec(client):
     rv = client.get("/apidoc")
     assert rv.status_code == 200
     assert b"Terracotta" in rv.data
+
+
+@pytest.mark.parametrize(
+    "stretch_range_params",
+    [
+        ['["s2", "p98"]', "Percentile format is"],
+        ['["pp2", "p98"]', "Percentile format is"],
+        ['["p", "p98"]', "Percentile format is"],
+        ['["2", "p98"]', "Percentile format is"],
+        ['["[]", "p98"]', "Percentile format is"],
+    ],
+)
+def test_get_rgb_invalid_stretch_percentile(
+    debug_client, use_testdb, raster_file_xyz, stretch_range_params
+):
+
+    x, y, z = raster_file_xyz
+    stretch_range = stretch_range_params[0]
+    with pytest.raises(marshmallow.ValidationError) as ve:
+        debug_client.get(
+            f"/rgb/val21/x/{z}/{x}/{y}.png?r=val22&g=val23&b=val24&"
+            f"r_range={stretch_range}&b_range={stretch_range}&g_range={stretch_range}"
+        )
+    assert stretch_range_params[1] in str(ve.value)

--- a/tests/server/test_flask_api.py
+++ b/tests/server/test_flask_api.py
@@ -581,9 +581,9 @@ def test_get_rgb_invalid_stretch_percentile(
 
     x, y, z = raster_file_xyz
     stretch_range = stretch_range_params[0]
-    with pytest.raises(marshmallow.ValidationError) as ve:
+    with pytest.raises(marshmallow.ValidationError) as exc:
         debug_client.get(
             f"/rgb/val21/x/{z}/{x}/{y}.png?r=val22&g=val23&b=val24&"
             f"r_range={stretch_range}&b_range={stretch_range}&g_range={stretch_range}"
         )
-    assert stretch_range_params[1] in str(ve.value)
+    assert stretch_range_params[1] in str(exc.value)

--- a/tests/server/test_flask_api.py
+++ b/tests/server/test_flask_api.py
@@ -410,6 +410,8 @@ def test_get_rgb_stretch(client, use_testdb, raster_file_xyz):
 
     for stretch_range in (
         "[0,10000]",
+        "[\"1.0e%2B01\",\"1.0e%2B04\"]",
+        "[\"p2\",\"p98\"]",
         "[0,null]",
         "[null, 10000]",
         "[null,null]",

--- a/tests/server/test_flask_api.py
+++ b/tests/server/test_flask_api.py
@@ -339,6 +339,7 @@ def test_get_singleband_stretch(client, use_testdb, raster_file_xyz):
         "[null,null]",
         "null",
         '["p2","p98"]',
+        '[0, "p98"]',
     ):
         rv = client.get(
             f"/singleband/val11/x/val12/{z}/{x}/{y}.png?stretch_range={stretch_range}"

--- a/tests/server/test_flask_api.py
+++ b/tests/server/test_flask_api.py
@@ -331,7 +331,14 @@ def test_get_singleband_stretch(client, use_testdb, raster_file_xyz):
 
     x, y, z = raster_file_xyz
 
-    for stretch_range in ("[0,1]", "[0,null]", "[null, 1]", "[null,null]", "null"):
+    for stretch_range in (
+        "[0,1]",
+        "[0,null]",
+        "[null, 1]",
+        "[null,null]",
+        "null",
+        '["p2","p98"]',
+    ):
         rv = client.get(
             f"/singleband/val11/x/val12/{z}/{x}/{y}.png?stretch_range={stretch_range}"
         )
@@ -410,8 +417,8 @@ def test_get_rgb_stretch(client, use_testdb, raster_file_xyz):
 
     for stretch_range in (
         "[0,10000]",
-        "[\"1.0e%2B01\",\"1.0e%2B04\"]",
-        "[\"p2\",\"p98\"]",
+        "[1.0e%2B01,1.0e%2B04]",
+        '["p2","p98"]',
         "[0,null]",
         "[null, 10000]",
         "[null,null]",


### PR DESCRIPTION
Add support for using percentiles instead of absolute values for the `/rgb`'s endpoint `*_range` parameters.

gives us the possibility to request the `/rgb?r_range=p2,p97...` instead of calling `/metadata` first to fetch the pct's absolute values in order to construct an `/rgb` url