### PR TITLE
Remove numpy version upper bound restriction

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - numpy
   - rasterio>=1.3.0
   - shapely
-  - crick
   - pip
   - pip:
+    - crick
     - -e .[recommended]

--- a/setup.py
+++ b/setup.py
@@ -17,9 +17,6 @@ long_description = re.sub(
 
 numpy_version = ">=1.15,!=1.17.0"
 
-# TODO: remove when crick is updated
-numpy_version += ",<1.24"
-
 setup(
     # metadata
     name="terracotta",

--- a/terracotta/image.py
+++ b/terracotta/image.py
@@ -156,6 +156,8 @@ def to_uint8(data: Array, lower_bound: Number, upper_bound: Number) -> Array:
     """Re-scale an array to [1, 255] and cast to uint8 (0 is used for transparency)"""
     rescaled = contrast_stretch(data, (lower_bound, upper_bound), (1, 255), clip=True)
     rescaled = np.rint(rescaled)
+    # explicitly set NaNs to 0 to avoid warnings
+    rescaled[~np.isfinite(rescaled)] = 0
     return rescaled.astype(np.uint8)
 
 


### PR DESCRIPTION
We don't need numpy<1.24 restriction as crick==0.0.4 is released https://pypi.org/project/crick/0.0.4/